### PR TITLE
Renamable preset collections

### DIFF
--- a/src/Commands/InstallPresetPresets.php
+++ b/src/Commands/InstallPresetPresets.php
@@ -21,44 +21,47 @@ trait InstallPresetPresets {
             [
                 'handle' => 'clients',
                 'name' => 'Clients',
-                'description' => 'A routeless client collection with a logo cloud page builder block.',
+                'description' => 'A routeless renamble client/partner collection with a logo cloud page builder block.',
                 'operations' => [
+                    [
+                        'type' => 'rename'
+                    ],
                     [
                         'type' => 'copy',
                         'input' => 'clients_blueprint.yaml.stub',
-                        'output' => 'resources/blueprints/collections/clients/clients.yaml'
+                        'output' => 'resources/blueprints/collections/{{ handle }}/{{ handle }}.yaml'
                     ],
                     [
                         'type' => 'copy',
                         'input' => 'clients_collection.yaml.stub',
-                        'output' => 'content/collections/clients.yaml'
+                        'output' => 'content/collections/{{ handle }}.yaml'
                     ],
                     [
                         'type' => 'copy',
                         'input' => 'clients.antlers.html.stub',
-                        'output' => 'resources/views/page_builder/_clients.antlers.html'
+                        'output' => 'resources/views/page_builder/_{{ handle }}.antlers.html'
                     ],
                     [
                         'type' => 'copy',
                         'input' => 'clients_fieldset.yaml.stub',
-                        'output' => 'resources/fieldsets/clients.yaml'
+                        'output' => 'resources/fieldsets/{{ handle }}.yaml'
                     ],
                     [
                         'type' => 'update_page_builder',
                         'block' => [
-                            'name' => 'Clients',
-                            'instructions' => 'A client logo cloud.',
-                            'handle' => 'clients',
+                            'name' => '{{ name }}',
+                            'instructions' => 'A {{ name }} logo cloud.',
+                            'handle' => '{{ handle }}',
                         ]
                     ],
                     [
                         'type' => 'update_role',
                         'role' => 'editor',
-                        'permissions' => ['view clients entries', 'edit clients entries', 'create clients entries', 'delete clients entries', 'publish clients entries', 'reorder clients entries', 'edit other authors clients entries', 'publish other authors clients entries', 'delete other authors clients entries']
+                        'permissions' => ['view {{ handle }} entries', 'edit {{ handle }} entries', 'create {{ handle }} entries', 'delete {{ handle }} entries', 'publish {{ handle }} entries', 'reorder {{ handle }} entries', 'edit other authors {{ handle }} entries', 'publish other authors {{ handle }} entries', 'delete other authors {{ handle }} entries']
                     ],
                     [
                         'type' => 'notify',
-                        'content' => "Add this to your `config/statamic/cp.php` widgets array:\n\n[\n\t'type' => 'collection',\n\t'collection' => 'clients',\n\t'width' => 50\n],"
+                        'content' => "Add this to your `config/statamic/cp.php` widgets array:\n\n[\n\t'type' => 'collection',\n\t'collection' => '{{ handle }}',\n\t'width' => 50\n],"
                     ]
                 ]
             ],

--- a/src/Commands/InstallPresetPresets.php
+++ b/src/Commands/InstallPresetPresets.php
@@ -259,8 +259,11 @@ trait InstallPresetPresets {
             [
                 'handle' => 'news',
                 'name' => 'News',
-                'description' => 'A dated news collection with index and show templates (including JSON-ld) and a page builder set.',
+                'description' => 'A dated renamable news/blog collection with index and show templates (including JSON-ld) and a page builder set.',
                 'operations' => [
+                    [
+                        'type' => 'rename'
+                    ],
                     [
                         'type' => 'copy',
                         'input' => 'index_content.antlers.html.stub',
@@ -274,42 +277,42 @@ trait InstallPresetPresets {
                     [
                         'type' => 'copy',
                         'input' => 'index.antlers.html.stub',
-                        'output' => 'resources/views/news/index.antlers.html'
+                        'output' => 'resources/views/{{ handle }}/index.antlers.html'
                     ],
                     [
                         'type' => 'copy',
                         'input' => 'news_blueprint.yaml.stub',
-                        'output' => 'resources/blueprints/collections/news/news.yaml'
+                        'output' => 'resources/blueprints/collections/{{ handle }}/{{ handle }}.yaml'
                     ],
                     [
                         'type' => 'copy',
                         'input' => 'news_collection.yaml.stub',
-                        'output' => 'content/collections/news.yaml'
+                        'output' => 'content/collections/{{ handle }}.yaml'
                     ],
                     [
                         'type' => 'copy',
                         'input' => 'news_fieldset.yaml.stub',
-                        'output' => 'resources/fieldsets/news.yaml'
+                        'output' => 'resources/fieldsets/{{ handle }}.yaml'
                     ],
                     [
                         'type' => 'copy',
                         'input' => 'news_item.antlers.html.stub',
-                        'output' => 'resources/views/components/_news_item.antlers.html'
+                        'output' => 'resources/views/components/_{{ handle }}_item.antlers.html'
                     ],
                     [
                         'type' => 'copy',
                         'input' => 'news.antlers.html.stub',
-                        'output' => 'resources/views/page_builder/_news.antlers.html'
+                        'output' => 'resources/views/page_builder/_{{ handle }}.antlers.html'
                     ],
                     [
                         'type' => 'copy',
                         'input' => 'news.md.stub',
-                        'output' => 'content/collections/pages/news.md'
+                        'output' => 'content/collections/pages/{{ handle }}.md'
                     ],
                     [
                         'type' => 'copy',
                         'input' => 'show.antlers.html.stub',
-                        'output' => 'resources/views/news/show.antlers.html'
+                        'output' => 'resources/views/{{ handle }}/show.antlers.html'
                     ],
                     [
                         'type' => 'update_page_builder',
@@ -322,23 +325,23 @@ trait InstallPresetPresets {
                     [
                         'type' => 'update_page_builder',
                         'block' => [
-                            'name' => 'News',
-                            'instructions' => 'List the most recent news.',
-                            'handle' => 'news',
+                            'name' => '{{ name }}',
+                            'instructions' => 'List the most recent {{ name }}.',
+                            'handle' => '{{ handle }}',
                         ]
                     ],
                     [
                         'type' => 'update_role',
                         'role' => 'editor',
-                        'permissions' => ['view news entries', 'edit news entries', 'create news entries', 'delete news entries', 'publish news entries', 'reorder news entries', 'edit other authors news entries', 'publish other authors news entries', 'delete other authors news entries']
+                        'permissions' => ['view {{ handle }} entries', 'edit {{ handle }} entries', 'create {{ handle }} entries', 'delete {{ handle }} entries', 'publish {{ handle }} entries', 'reorder {{ handle }} entries', 'edit other authors {{ handle }} entries', 'publish other authors {{ handle }} entries', 'delete other authors {{ handle }} entries']
                     ],
                     [
                         'type' => 'notify',
-                        'content' => "Add this to your `lang/locale/strings.php` file:\n\n// News\n'news_all' => 'All news',\n'news_more' => 'More news',"
+                        'content' => "Add this to your `lang/locale/strings.php` file:\n\n// {{ name }}\n'{{ handle }}_all' => 'All {{ name }}',\n'{{ handle }}_more' => 'More {{ name }}',"
                     ],
                     [
                         'type' => 'notify',
-                        'content' => "Add this to your `config/statamic/cp.php` widgets array:\n\n[\n\t'type' => 'collection',\n\t'collection' => 'news',\n\t'width' => 50\n],"
+                        'content' => "Add this to your `config/statamic/cp.php` widgets array:\n\n[\n\t'type' => 'collection',\n\t'collection' => '{{ handle }}',\n\t'width' => 50\n],"
                     ]
                 ]
             ],

--- a/src/Commands/InstallPresetPresets.php
+++ b/src/Commands/InstallPresetPresets.php
@@ -21,7 +21,7 @@ trait InstallPresetPresets {
             [
                 'handle' => 'clients',
                 'name' => 'Clients',
-                'description' => 'A routeless renamble client/partner collection with a logo cloud page builder block.',
+                'description' => 'A routeless renamable client/partner collection with a logo cloud page builder block.',
                 'operations' => [
                     [
                         'type' => 'rename'
@@ -68,37 +68,40 @@ trait InstallPresetPresets {
             [
                 'handle' => 'events',
                 'name' => 'Events',
-                'description' => 'A dated events collection with index and show templates (including JSON-ld) and a page builder set.',
+                'description' => 'A dated renamable events collection with index and show templates (including JSON-ld) and a page builder set.',
                 'operations' => [
+                    [
+                        'type' => 'rename'
+                    ],
                     [
                         'type' => 'copy',
                         'input' => 'events_blueprint.yaml.stub',
-                        'output' => 'resources/blueprints/collections/events/events.yaml'
+                        'output' => 'resources/blueprints/collections/{{ handle }}/{{ handle }}.yaml'
                     ],
                     [
                         'type' => 'copy',
                         'input' => 'events_collection.yaml.stub',
-                        'output' => 'content/collections/events.yaml'
+                        'output' => 'content/collections/{{ handle }}.yaml'
                     ],
                     [
                         'type' => 'copy',
                         'input' => 'events_fieldset.yaml.stub',
-                        'output' => 'resources/fieldsets/events.yaml'
+                        'output' => 'resources/fieldsets/{{ handle }}.yaml'
                     ],
                     [
                         'type' => 'copy',
                         'input' => 'events_item.antlers.html.stub',
-                        'output' => 'resources/views/components/_events_item.antlers.html'
+                        'output' => 'resources/views/components/_{{ handle }}_item.antlers.html'
                     ],
                     [
                         'type' => 'copy',
                         'input' => 'events.antlers.html.stub',
-                        'output' => 'resources/views/page_builder/_events.antlers.html'
+                        'output' => 'resources/views/page_builder/_{{ handle }}.antlers.html'
                     ],
                     [
                         'type' => 'copy',
                         'input' => 'events.md.stub',
-                        'output' => 'content/collections/pages/events.md'
+                        'output' => 'content/collections/pages/{{ handle }}.md'
                     ],
                     [
                         'type' => 'copy',
@@ -113,12 +116,12 @@ trait InstallPresetPresets {
                     [
                         'type' => 'copy',
                         'input' => 'index.antlers.html.stub',
-                        'output' => 'resources/views/events/index.antlers.html'
+                        'output' => 'resources/views/{{ handle }}/index.antlers.html'
                     ],
                     [
                         'type' => 'copy',
                         'input' => 'show.antlers.html.stub',
-                        'output' => 'resources/views/events/show.antlers.html'
+                        'output' => 'resources/views/{{ handle }}/show.antlers.html'
                     ],
                     [
                         'type' => 'update_page_builder',
@@ -131,23 +134,23 @@ trait InstallPresetPresets {
                     [
                         'type' => 'update_page_builder',
                         'block' => [
-                            'name' => 'Events',
-                            'instructions' => 'List upcoming events.',
-                            'handle' => 'events',
+                            'name' => '{{ name }}',
+                            'instructions' => 'List upcoming {{ name }}.',
+                            'handle' => '{{ handle }}',
                         ]
                     ],
                     [
                         'type' => 'update_role',
                         'role' => 'editor',
-                        'permissions' => ['view events entries', 'edit events entries', 'create events entries', 'delete events entries', 'publish events entries', 'reorder events entries', 'edit other authors events entries', 'publish other authors events entries', 'delete other authors events entries']
+                        'permissions' => ['view {{ handle }} entries', 'edit {{ handle }} entries', 'create {{ handle }} entries', 'delete {{ handle }} entries', 'publish {{ handle }} entries', 'reorder {{ handle }} entries', 'edit other authors {{ handle }} entries', 'publish other authors {{ handle }} entries', 'delete other authors {{ handle }} entries']
                     ],
                     [
                         'type' => 'notify',
-                        'content' => "Add this to your `lang/locale/strings.php` file:\n\n// Events\n'events_all' => 'All events',\n'events_date' => 'Date',\n'events_date_start' => 'Start date',\n'events_date_end' => 'End date',\n'events_more' => 'More events',\n'events_when' => 'When',\n'events_where' => 'Where',\n'events_organizer' => 'Organizer',\n'events_tickets' => 'Tickets',"
+                        'content' => "Add this to your `lang/locale/strings.php` file:\n\n// {{ name }}\n'{{ handle }}_all' => 'All {{ name }}',\n'{{ handle }}_date' => 'Date',\n'{{ handle }}_date_start' => 'Start date',\n'{{ handle }}_date_end' => 'End date',\n'{{ handle }}_more' => 'More {{ name }}',\n'{{ handle }}_when' => 'When',\n'{{ handle }}_where' => 'Where',\n'{{ handle }}_organizer' => 'Organizer',\n'{{ handle }}_tickets' => 'Tickets',"
                     ],
                     [
                         'type' => 'notify',
-                        'content' => "Add this to your `config/statamic/cp.php` widgets array:\n\n[\n\t'type' => 'collection',\n\t'collection' => 'events',\n\t'width' => 50\n],"
+                        'content' => "Add this to your `config/statamic/cp.php` widgets array:\n\n[\n\t'type' => 'collection',\n\t'collection' => '{{ handle }}',\n\t'width' => 50\n],"
                     ]
                 ]
             ],

--- a/src/Commands/stubs/presets/clients/clients.antlers.html.stub
+++ b/src/Commands/stubs/presets/clients/clients.antlers.html.stub
@@ -1,23 +1,23 @@
 {{#
-    @name Clients
-    @desc The Clients page builder block.
-    @set page.page_builder.clients
+    @name {{ name }}
+    @desc The {{ name }} page builder block.
+    @set page.page_builder.{{ handle }}
 #}}
 
-<!-- /page_builder/_clients.antlers.html -->
+<!-- /page_builder/_{{ handle }}.antlers.html -->
 <section class="fluid-container grid grid-cols-2 md:grid-cols-10 gap-12 place-items-center">
     {{ block:title ?= { partial:typography/h2 :content="block:title" class="col-span-2 md:col-span-12" } }}
 
     {{
-        clients = block:clients
-            ? block:clients
-            : { collection:clients sort="order" }
+        {{ handle }} = block:{{ handle }}
+            ? block:{{ handle }}
+            : { collection:{{ handle }} sort="order" }
     }}
 
-    {{ clients }}
+    {{ {{ handle }} }}
         <a class="md:col-span-2 p-1 -m-1 hover:scale-105 motion-safe:transition-transform focus:outline-none focus-visible:ring-2 focus-visible:ring-primary group" href="{{ website }}" target="_blank" rel="noopener" aria-label="{{ title }}">
             {{ partial:components/picture :image="logo" class="grayscale group-focus-visible:grayscale-0 group-hover:grayscale-0 motion-safe:transition" }}
         </a>
-    {{ /clients }}
+    {{ /{{ handle }} }}
 </section>
-<!-- End: /page_builder/_clients.antlers.html -->
+<!-- End: /page_builder/_{{ handle }}.antlers.html -->

--- a/src/Commands/stubs/presets/clients/clients_blueprint.yaml.stub
+++ b/src/Commands/stubs/presets/clients/clients_blueprint.yaml.stub
@@ -1,4 +1,4 @@
-title: Clients
+title: {{ name }}
 sections:
   main:
     display: Main

--- a/src/Commands/stubs/presets/clients/clients_collection.yaml.stub
+++ b/src/Commands/stubs/presets/clients/clients_collection.yaml.stub
@@ -1,4 +1,4 @@
-title: Clients
+title: {{ name }}
 template: default
 layout: layout
 revisions: false

--- a/src/Commands/stubs/presets/clients/clients_fieldset.yaml.stub
+++ b/src/Commands/stubs/presets/clients/clients_fieldset.yaml.stub
@@ -1,4 +1,4 @@
-title: Clients
+title: {{ name }}
 fields:
   -
     handle: title
@@ -13,16 +13,16 @@ fields:
       visibility: visible
       always_save: false
   -
-    handle: clients
+    handle: {{ handle }}
     field:
       mode: default
       create: true
       collections:
-        - clients
-      display: Clients
+        - {{ handle }}
+      display: {{ name }}
       type: entries
       icon: entries
-      instructions: 'Select cliënts or leave empty to show all.'
+      instructions: 'Select entries or leave empty to show all.'
       listable: hidden
       instructions_position: below
       visibility: visible

--- a/src/Commands/stubs/presets/events/events.antlers.html.stub
+++ b/src/Commands/stubs/presets/events/events.antlers.html.stub
@@ -1,27 +1,27 @@
 {{#
-	@name Events
-	@desc The Events page builder block.
-    @set page.page_builder.events
+	@name {{ name }}
+	@desc The {{ name }} page builder block.
+    @set page.page_builder.{{ handle }}
 #}}
 
-<!-- /page_builder/_events.antlers.html -->
+<!-- /page_builder/_{{ handle }}.antlers.html -->
 <section class="fluid-container grid md:grid-cols-12 gap-8">
     {{ title ?= { partial:typography/h1 as="h2" :content="title" class="md:col-span-12" } }}
 
-    {{ collection:events sort="event_date_start:asc" event_date_end:is_after="{ today }" limit="3" as="items" }}
+    {{ collection:{{ handle }} sort="{{ singular_handle }}_date_start:asc" {{ singular_handle }}_date_end:is_after="{ today }" limit="3" as="items" }}
         {{ unless no_results }}
             {{ items }}
-                {{ partial:components/events_item class="md:col-span-4" }}
+                {{ partial:components/{{ handle }}_item class="md:col-span-4" }}
             {{ /items }}
         {{ else }}
             <div class="md:col-span-6">
                 {{ trans:strings.no_results }}
             </div>
         {{ /if }}
-    {{ /collection:events }}
+    {{ /collection:{{ handle }} }}
 
     <nav class="md:col-span-12 text-right">
-        {{ partial:components/button label="{trans:strings.events_all}" button_type="inline" link_type="url" url="{mount_url:events}" }}
+        {{ partial:components/button label="{trans:strings.{{ handle }}_all}" button_type="inline" link_type="url" url="{mount_url:{{ handle }}}" }}
     </nav>
 </section>
-<!-- End: /page_builder/_events.antlers.html -->
+<!-- End: /page_builder/_{{ handle }}.antlers.html -->

--- a/src/Commands/stubs/presets/events/events.md.stub
+++ b/src/Commands/stubs/presets/events/events.md.stub
@@ -1,8 +1,8 @@
 ---
 id: ba821fde-cfa2-428d-b5c4-191f9c8e973d
 blueprint: page
-title: Events
-template: events/index
+title: {{ name }}
+template: {{ handle }}/index
 page_builder:
   -
     type: index_content

--- a/src/Commands/stubs/presets/events/events_blueprint.yaml.stub
+++ b/src/Commands/stubs/presets/events/events_blueprint.yaml.stub
@@ -1,13 +1,8 @@
-title: Events
+title: {{ name }}
 sections:
   main:
     display: Main
     fields:
-      -
-        handle: events
-        field:
-          default: events
-          type: hidden
       -
         handle: title
         field:
@@ -29,22 +24,22 @@ sections:
           character_limit: '250'
       -
         import: page_builder
-  event:
-    display: Event
+  {{ singular_handle }}:
+    display: {{ singular_name }}
     fields:
       -
         handle: section_date
         field:
-          display: 'Event date'
+          display: '{{ singular_name }} date'
           type: section
           icon: section
-          instructions: 'Event date or dates.'
+          instructions: '{{ singular_name }} date or dates.'
           listable: hidden
           instructions_position: above
           visibility: visible
           always_save: false
       -
-        handle: event_date_start
+        handle: {{ singular_handle }}_date_start
         field:
           time_enabled: false
           time_seconds_enabled: false
@@ -52,7 +47,7 @@ sections:
           inline: false
           columns: 1
           rows: 1
-          display: 'Event date (start)'
+          display: '{{ singular_name }} date (start)'
           type: date
           icon: date
           listable: true
@@ -63,7 +58,7 @@ sections:
           validate:
             - required
       -
-        handle: event_date_end
+        handle: {{ singular_handle }}_date_end
         field:
           time_enabled: false
           time_seconds_enabled: false
@@ -71,7 +66,7 @@ sections:
           inline: false
           columns: 1
           rows: 1
-          display: 'Event date (end)'
+          display: '{{ singular_name }} date (end)'
           type: date
           icon: date
           listable: true
@@ -87,13 +82,13 @@ sections:
           display: 'Status en location'
           type: section
           icon: section
-          instructions: 'Event status and location details.'
+          instructions: '{{ singular_name }} status and location details.'
           listable: hidden
           instructions_position: above
           visibility: visible
           always_save: false
       -
-        handle: event_type
+        handle: {{ singular_handle }}_type
         field:
           options:
             offline: Offline
@@ -105,7 +100,7 @@ sections:
           push_tags: false
           cast_booleans: false
           default: offline
-          display: 'Event type'
+          display: '{{ singular_name }} type'
           type: select
           icon: select
           listable: hidden
@@ -116,14 +111,14 @@ sections:
             - required
           width: 50
       -
-        handle: event_status
+        handle: {{ singular_handle }}_status
         field:
           options:
-            EventScheduled: 'Event scheduled as planned'
-            EventRescheduled: 'Event rescheduled (enter new dates)'
-            EventPostponed: 'Event postponed (new date not yet known)'
-            EventMovedOnline: 'Event moved to online (update location)'
-            EventCancelled: 'Event cancelled (keep values as is)'
+            EventScheduled: '{{ singular_name }} scheduled as planned'
+            EventRescheduled: '{{ singular_name }} rescheduled (enter new dates)'
+            EventPostponed: '{{ singular_name }} postponed (new date not yet known)'
+            EventMovedOnline: '{{ singular_name }} moved to online (update location)'
+            EventCancelled: '{{ singular_name }} cancelled (keep values as is)'
           multiple: false
           clearable: false
           searchable: false
@@ -131,7 +126,7 @@ sections:
           push_tags: false
           cast_booleans: false
           default: EventScheduled
-          display: 'Event status'
+          display: '{{ singular_name }} status'
           type: select
           icon: select
           width: 50
@@ -155,7 +150,7 @@ sections:
             - required
             - sometimes
           if:
-            event_type: 'equals offline'
+            {{ singular_handle }}_type: 'equals offline'
       -
         handle: location_address
         field:
@@ -173,7 +168,7 @@ sections:
             - required
             - sometimes
           if:
-            event_type: 'equals offline'
+            {{ singular_handle }}_type: 'equals offline'
       -
         handle: location_locality
         field:
@@ -191,13 +186,13 @@ sections:
             - required
             - sometimes
           if:
-            event_type: 'equals offline'
+            {{ singular_handle }}_type: 'equals offline'
       -
-        handle: event_url
+        handle: {{ singular_handle }}_url
         field:
           input_type: url
           antlers: false
-          display: 'Event URL'
+          display: '{{ singular_name }} URL'
           type: text
           icon: text
           listable: hidden
@@ -208,14 +203,14 @@ sections:
             - required
             - sometimes
           if:
-            event_type: 'equals online'
+            {{ singular_handle }}_type: 'equals online'
       -
         handle: section_organizer
         field:
           display: 'Organizer'
           type: section
           icon: section
-          instructions: 'Event organizer details.'
+          instructions: '{{ singular_name }} organizer details.'
           listable: hidden
           instructions_position: above
           visibility: visible

--- a/src/Commands/stubs/presets/events/events_collection.yaml.stub
+++ b/src/Commands/stubs/presets/events/events_collection.yaml.stub
@@ -1,5 +1,5 @@
-title: Events
-template: events/show
+title: {{ name }}
+template: {{ handle }}/show
 layout: layout
 revisions: false
 route: '/{mount}/{slug}'

--- a/src/Commands/stubs/presets/events/events_fieldset.yaml.stub
+++ b/src/Commands/stubs/presets/events/events_fieldset.yaml.stub
@@ -1,4 +1,4 @@
-title: 'Events'
+title: '{{ name }}'
 fields:
   -
     handle: title

--- a/src/Commands/stubs/presets/events/events_item.antlers.html.stub
+++ b/src/Commands/stubs/presets/events/events_item.antlers.html.stub
@@ -1,23 +1,23 @@
 {{#
-	@name Events item
-	@desc A events item component.
+	@name {{ name }} item
+	@desc A {{ name }} item component.
 	@param class Add optional CSS classes.
 #}}
 
-<!-- /components/_events_item.antlers.html -->
+<!-- /components/_{{ handle }}_item.antlers.html -->
 <article class="flex flex-col {{ class }}">
 	<figure class="aspect-[3/2] mb-4">
 		{{ partial:components/picture :image="image" sizes="(min-width: 1280px) 430px, (min-width: 768px) 30vw, 90vw" aspect_ratio="3/2" lazy="true" cover="true" }}
 	</figure>
 
 	<div class="flex flex-col gap-y-2">
-		{{ if event_date_start != event_date_end }}
+		{{ if {{ singular_handle }}_date_start != {{ singular_handle }}_date_end }}
 			<time>
-				{{ partial:typography/time as="span" class="inline text-sm" :content="event_date_start" }} -
-				{{ partial:typography/time as="span" class="inline text-sm" :content="event_date_end" }}
+				{{ partial:typography/time as="span" class="inline text-sm" :content="{{ singular_handle }}_date_start" }} -
+				{{ partial:typography/time as="span" class="inline text-sm" :content="{{ singular_handle }}_date_end" }}
 			</time>
 		{{ else }}
-			{{ partial:typography/time class="inline text-sm" :content="event_date_start" }}
+			{{ partial:typography/time class="inline text-sm" :content="{{ singular_handle }}_date_start" }}
 		{{ /if }}
 
 		<a href="{{ url }}" class="group p-1 -m-1 focus:outline-none focus-visible:ring-2 ring-primary group">
@@ -27,4 +27,4 @@
 		{{ partial:typography/p :content="teaser" }}
 	</div>
 </article>
-<!-- End: /components/_events_item.antlers.html -->
+<!-- End: /components/_{{ handle }}_item.antlers.html -->

--- a/src/Commands/stubs/presets/events/index.antlers.html.stub
+++ b/src/Commands/stubs/presets/events/index.antlers.html.stub
@@ -1,24 +1,24 @@
 {{#
-	@name Events index
-	@desc The Events index template.
+	@name {{ name }} index
+	@desc The {{ name }} index template.
 #}}
 
-<!-- /events/index.antlers.html -->
+<!-- /{{ handle }}/index.antlers.html -->
 <main class="outer-grid" id="content">
     {{ page_builder scope="block" }}
         {{ partial src="page_builder/{type}" }}
     {{ /page_builder }}
 </main>
-<!-- End: /events/index.antlers.html -->
+<!-- End: /{{ handle }}/index.antlers.html -->
 
 {{ section:index_content }}
-    <!-- /events/index.antlers.html -->
+    <!-- /{{ handle }}/index.antlers.html -->
     <div class="fluid-container self-start grid md:grid-cols-12 gap-8">
         {{ partial:typography/h1 as="h2" :content="title" class="md:col-span-12" }}
-        {{ collection:events sort="event_date_start:asc" event_date_end:is_after="{ today }" paginate="true" limit="12" as="items" }}
+        {{ collection:{{ handle }} sort="{{ singular_handle }}_date_start:asc" {{ singular_handle }}_date_end:is_after="{ today }" paginate="true" limit="12" as="items" }}
             {{ unless no_results }}
                 {{ items }}
-                    {{ partial:components/events_item class="md:col-span-4" }}
+                    {{ partial:components/{{ handle }}_item class="md:col-span-4" }}
                 {{ /items }}
             {{ else }}
                 <div class="md:col-span-6">
@@ -27,7 +27,7 @@
             {{ /unless }}
 
             {{ partial:components/pagination class="md:col-span-12" }}
-        {{ /collection:events }}
+        {{ /collection:{{ handle }} }}
     </div>
-    <!-- End: /events/index.antlers.html -->
+    <!-- End: /{{ handle }}/index.antlers.html -->
 {{ /section:index_content }}

--- a/src/Commands/stubs/presets/events/show.antlers.html.stub
+++ b/src/Commands/stubs/presets/events/show.antlers.html.stub
@@ -1,18 +1,18 @@
 {{#
-	@name Events show
-	@desc The Events show template.
+	@name {{ name }} show
+	@desc The {{ name }} show template.
 #}}
 
-<!-- /events/show.antlers.html -->
+<!-- /{{ handle }}/show.antlers.html -->
 <script type="application/ld+json">
     {
         "@context": "https://schema.org",
         "@type": "Event",
         "name": "{{ title }}",
-        "startDate": "{{ event_date_start format="Y-m-d\TH:i:s" }}",
-        "endDate": "{{ event_date_end format="Y-m-d\TH:i:s" }}",
-        "eventStatus": "https://schema.org/EventScheduled",
-        {{ if event_type.value == 'offline' }}
+        "startDate": "{{ {{ singular_handle}}_date_start format="Y-m-d\TH:i:s" }}",
+        "endDate": "{{ {{ singular_handle}}_date_end format="Y-m-d\TH:i:s" }}",
+        "eventStatus": "https://schema.org/{{ {{ singular_handle }}_status }}",
+        {{ if {{ singular_handle }}_type.value == 'offline' }}
             "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
             "location": {
                 "@type": "Place",
@@ -24,11 +24,11 @@
                     "addressCountry": "NL"
                 }
             },
-        {{ elseif event_type.value == 'online' }}
+        {{ elseif {{ singular_handle }}_type.value == 'online' }}
             "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
             "location": {
                 "@type": "VirtualLocation",
-                "url": "{{ event_url }}"
+                "url": "{{ {{ singular_handle }}_url }}"
             },
         {{ /if }}
         "image": "{{ config:app:url }}{{ image }}",
@@ -52,26 +52,26 @@
         </header>
 
         <aside class="size-md p-6 md:p-8 grid md:grid-cols-3 gap-2 md:gap-8 border border-neutral/10 shadow-lg rounded">
-            {{ partial:typography/h3 content="{trans:strings.events_when}" }}
+            {{ partial:typography/h3 content="{trans:strings.{{ handle }}_when}" }}
             <time class="md:col-span-2 mb-4 md:mb-0" lang="{{ locale }}">
-                {{ event_date_start | iso_format('D MMM YYYY') }}{{ event_date_end ?= " - " + { event_date_end | iso_format('D MMM YYYY') } }}
+                {{ {{ singular_handle }}_date_start | iso_format('D MMM YYYY') }}{{ {{ singular_handle }}_date_end ?= " - " + { {{ singular_handle }}_date_end | iso_format('D MMM YYYY') } }}
             </time>
-            {{ partial:typography/h3 content="{trans:strings.events_where}" }}
+            {{ partial:typography/h3 content="{trans:strings.{{ handle }}_where}" }}
             <div class="md:col-span-2 mb-4 md:mb-0">
-                {{ if event_type.value === 'offline' }}
+                {{ if {{ singular_handle }}_type.value === 'offline' }}
                     {{ location_name }}<br>
                     {{ location_address }}<br>
                     {{ location_locality }}
                 {{ else }}
-                    <a class="underline decoration-2 decoration-primary" href="{{ event_url }}" rel="noopener" target="_blank">Online</a>
+                    <a class="underline decoration-2 decoration-primary" href="{{ {{ singular_handle }}_url }}" rel="noopener" target="_blank">Online</a>
                 {{ /if }}
             </div>
-            {{ partial:typography/h3 content="{trans:strings.events_organizer}" }}
+            {{ partial:typography/h3 content="{trans:strings.{{ handle }}_organizer}" }}
             <div class="md:col-span-2 mb-4 md:mb-0">
                 <a class="underline decoration-2 decoration-primary" href="{{ organizer_url }}" rel="noopener" target="_blank">{{ organizer_name }}</a>
             </div>
             {{ if sign_up_label }}
-                {{ partial:typography/h3 content="{trans:strings.events_tickets}" }}
+                {{ partial:typography/h3 content="{trans:strings.{{ handle }}_tickets}" }}
                 <div class="md:col-span-2">
                     {{ partial:components/button :label="sign_up_label" link_type :target_blank="sign_up_target_blank" :entry="sign_up_entry" :url="sign_up_url" :email="sign_up_email" :tel="sign_up_tel" :asset="sign_up_asset" :button_type="sign_up_button_type" :attr_title="sign_up_attr_title" :attr_aria="sign_up_attr_aria" }}
                 </div>
@@ -83,16 +83,16 @@
         {{ partial src="page_builder/{type}" }}
     {{ /page_builder }}
 
-    {{ collection:events sort="event_date_start:asc" event_date_end:is_after="{ today }" :id:isnt="id" limit="3" as="items" }}
+    {{ collection:{{ handle }} sort="{{ singular_handle }}_date_start:asc" {{ singular_handle }}_date_end:is_after="{ today }" :id:isnt="id" limit="3" as="items" }}
         {{ unless no_results }}
             <section class="fluid-container grid md:grid-cols-12 gap-8">
-                {{ partial:typography/h1 as="h2" content="{ trans:strings.events_more }" class="md:col-span-12" }}
+                {{ partial:typography/h1 as="h2" content="{ trans:strings.{{ handle }}_more }" class="md:col-span-12" }}
 
                 {{ items }}
-                    {{ partial:components/events_item class="md:col-span-4" }}
+                    {{ partial:components/{{ handle }}_item class="md:col-span-4" }}
                 {{ /items }}
             </section>
         {{ /unless }}
-    {{ /collection:events }}
+    {{ /collection:{{ handle }} }}
 </main>
-<!-- /events/show.antlers.html -->
+<!-- /{{ handle }}/show.antlers.html -->

--- a/src/Commands/stubs/presets/news/index.antlers.html.stub
+++ b/src/Commands/stubs/presets/news/index.antlers.html.stub
@@ -1,9 +1,9 @@
 {{#
-	@name News index
-	@desc The News index template.
+	@name {{ name }} index
+	@desc The {{ name }} index template.
 #}}
 
-<!-- /news/index.antlers.html -->
+<!-- /{{ handle }}/index.antlers.html -->
 <main class="outer-grid" id="content">
     {{ page_builder scope="block" }}
         {{ partial src="page_builder/{type}" }}
@@ -12,13 +12,13 @@
 <!-- End: /events/index.antlers.html -->
 
 {{ section:index_content }}
-    <!-- /news/index.antlers.html -->
+    <!-- /{{ handle }}/index.antlers.html -->
     <div class="fluid-container self-start grid md:grid-cols-12 gap-8">
         {{ partial:typography/h1 :content="title" class="md:col-span-12" }}
-        {{ collection:news sort="date:desc" paginate="true" limit="12" as="items" }}
+        {{ collection:{{ handle }} sort="date:desc" paginate="true" limit="12" as="items" }}
             {{ unless no_results }}
                 {{ items }}
-                    {{ partial:components/news_item class="md:col-span-4" }}
+                    {{ partial:components/{{ handle }}_item class="md:col-span-4" }}
                 {{ /items }}
             {{ else }}
                 <div class="md:col-span-6">
@@ -27,7 +27,7 @@
             {{ /unless }}
 
             {{ partial:components/pagination class="md:col-span-12" }}
-        {{ /collection:news }}
+        {{ /collection:{{ handle }} }}
     </div>
-    <!-- End: /news/index.antlers.html -->
+    <!-- End: /{{ handle }}/index.antlers.html -->
 {{ /section:index_content }}

--- a/src/Commands/stubs/presets/news/news.antlers.html.stub
+++ b/src/Commands/stubs/presets/news/news.antlers.html.stub
@@ -1,27 +1,27 @@
 {{#
-	@name News
-	@desc The News page builder block.
-    @set page.page_builder.news
+	@name {{ name }}
+	@desc The {{ name }} page builder block.
+    @set page.page_builder.{{ handle }}
 #}}
 
-<!-- /page_builder/_news.antlers.html -->
+<!-- /page_builder/_{{ handle }}.antlers.html -->
 <section class="fluid-container grid md:grid-cols-12 gap-8">
     {{ title ?= { partial:typography/h1 as="h2" :content="title" class="md:col-span-12" } }}
 
-    {{ collection:news sort="date:desc" limit="3" as="items" }}
+    {{ collection:{{ handle }} sort="date:desc" limit="3" as="items" }}
         {{ unless no_results }}
             {{ items }}
-                {{ partial:components/news_item class="md:col-span-4" }}
+                {{ partial:components/{{ handle }}_item class="md:col-span-4" }}
             {{ /items }}
         {{ else }}
             <div class="md:col-span-6">
                 {{ trans:strings.no_results }}
             </div>
         {{ /if }}
-    {{ /collection:news }}
+    {{ /collection:{{ handle }} }}
 
     <nav class="md:col-span-12 text-right">
-        {{ partial:components/button label="{trans:strings.news_all}" button_type="inline" link_type="url" url="{mount_url:news}" }}
+        {{ partial:components/button label="{trans:strings.{{ handle }}_all}" button_type="inline" link_type="url" url="{mount_url:{{ handle }}}" }}
     </nav>
 </section>
-<!-- End: /page_builder/_news.antlers.html -->
+<!-- End: /page_builder/_{{ handle }}.antlers.html -->

--- a/src/Commands/stubs/presets/news/news.md.stub
+++ b/src/Commands/stubs/presets/news/news.md.stub
@@ -1,8 +1,8 @@
 ---
 id: d11a5ec8-9915-4528-8cfe-e282362ef9ee
 blueprint: page
-title: News
-template: news/index
+title: {{ name }}
+template: {{ handle }}/index
 page_builder:
   -
     type: index_content

--- a/src/Commands/stubs/presets/news/news_blueprint.yaml.stub
+++ b/src/Commands/stubs/presets/news/news_blueprint.yaml.stub
@@ -1,4 +1,4 @@
-title: News
+title: {{ name }}
 sections:
   main:
     display: Main

--- a/src/Commands/stubs/presets/news/news_collection.yaml.stub
+++ b/src/Commands/stubs/presets/news/news_collection.yaml.stub
@@ -1,7 +1,7 @@
-title: News
+title: {{ name }}
 route: '/{mount}/{slug}'
 layout: layout
-template: news/show
+template: {{ handle }}/show
 revisions: false
 date: true
 sort_dir: desc

--- a/src/Commands/stubs/presets/news/news_fieldset.yaml.stub
+++ b/src/Commands/stubs/presets/news/news_fieldset.yaml.stub
@@ -1,4 +1,4 @@
-title: 'News'
+title: '{{ name }}'
 fields:
   -
     handle: title

--- a/src/Commands/stubs/presets/news/news_item.antlers.html.stub
+++ b/src/Commands/stubs/presets/news/news_item.antlers.html.stub
@@ -1,10 +1,10 @@
 {{#
-	@name News item
-	@desc A news item component.
+	@name {{ handle }} item
+	@desc A {{ name }} item component.
 	@param class Add optional CSS classes.
 #}}
 
-<!-- /components/_news_item.antlers.html -->
+<!-- /components/_{{ handle }}_item.antlers.html -->
 <article class="flex flex-col {{ class }}">
 	<figure class="aspect-[3/2] mb-4">
 		{{ partial:components/picture :image="image" sizes="(min-width: 1280px) 430px, (min-width: 768px) 30vw, 90vw" aspect_ratio="3/2" lazy="true" cover="true" }}
@@ -20,4 +20,4 @@
 		{{ partial:typography/p :content="teaser" }}
 	</div>
 </article>
-<!-- End: /components/_news_item.antlers.html -->
+<!-- End: /components/_{{ handle }}_item.antlers.html -->

--- a/src/Commands/stubs/presets/news/show.antlers.html.stub
+++ b/src/Commands/stubs/presets/news/show.antlers.html.stub
@@ -1,9 +1,9 @@
 {{#
-	@name News show
-	@desc The News show template.
+	@name {{ name }} show
+	@desc The {{ name }} show template.
 #}}
 
-<!-- /news/show.antlers.html -->
+<!-- /{{ handle }}/show.antlers.html -->
 <script type="application/ld+json">
     {
         "@context": "https://schema.org",
@@ -47,16 +47,16 @@
         {{ partial src="page_builder/{type}" }}
     {{ /page_builder }}
 
-    {{ collection:previous in="news" sort="date:asc" limit="1" as="items" }}
+    {{ collection:previous in="{{ handle }}" sort="date:asc" limit="1" as="items" }}
         {{ unless no_results }}
             <section class="fluid-container grid md:grid-cols-12 gap-8">
-                {{ partial:typography/h1 as="h2" content="{ trans:strings.news_more }" class="md:col-span-12" }}
+                {{ partial:typography/h1 as="h2" content="{ trans:strings.{{ handle }}_more }" class="md:col-span-12" }}
 
                 {{ items }}
-                    {{ partial:components/news_item class="md:col-span-4" }}
+                    {{ partial:components/{{ handle }}_item class="md:col-span-4" }}
                 {{ /items }}
             </section>
         {{ /unless }}
     {{ /collection:previous }}
 </main>
-<!-- /news/show.antlers.html -->
+<!-- /{{ handle }}/show.antlers.html -->


### PR DESCRIPTION
You can now rename preset collections when installing them with `php please peak:install-preset`.