### PR TITLE
Move namespace from `Studio1902\Peak` to `Studio1902\PeakCommands`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "studio1902/statamic-peak-commands",
     "autoload": {
         "psr-4": {
-            "Studio1902\\Peak\\": "src"
+            "Studio1902\\PeakCommands\\": "src"
         }
     },
     "extra": {
@@ -12,7 +12,7 @@
         },
         "laravel": {
             "providers": [
-                "Studio1902\\Peak\\ServiceProvider"
+                "Studio1902\\PeakCommands\\ServiceProvider"
             ]
         }
     }

--- a/src/Commands/AddBlock.php
+++ b/src/Commands/AddBlock.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Studio1902\Peak\Commands;
+namespace Studio1902\PeakCommands\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;

--- a/src/Commands/AddCollection.php
+++ b/src/Commands/AddCollection.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Studio1902\Peak\Commands;
+namespace Studio1902\PeakCommands\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;

--- a/src/Commands/AddPartial.php
+++ b/src/Commands/AddPartial.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Studio1902\Peak\Commands;
+namespace Studio1902\PeakCommands\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;

--- a/src/Commands/AddSet.php
+++ b/src/Commands/AddSet.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Studio1902\Peak\Commands;
+namespace Studio1902\PeakCommands\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;

--- a/src/Commands/ClearSite.php
+++ b/src/Commands/ClearSite.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Studio1902\Peak\Commands;
+namespace Studio1902\PeakCommands\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;

--- a/src/Commands/InstallBlock.php
+++ b/src/Commands/InstallBlock.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Studio1902\Peak\Commands;
+namespace Studio1902\PeakCommands\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;

--- a/src/Commands/InstallBlockBlocks.php
+++ b/src/Commands/InstallBlockBlocks.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Studio1902\Peak\Commands;
+namespace Studio1902\PeakCommands\Commands;
 
 trait InstallBlockBlocks {
 

--- a/src/Commands/InstallPreset.php
+++ b/src/Commands/InstallPreset.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Studio1902\Peak\Commands;
+namespace Studio1902\PeakCommands\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;

--- a/src/Commands/InstallPresetPresets.php
+++ b/src/Commands/InstallPresetPresets.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Studio1902\Peak\Commands;
+namespace Studio1902\PeakCommands\Commands;
 
 trait InstallPresetPresets {
 

--- a/src/Commands/SharedFunctions.php
+++ b/src/Commands/SharedFunctions.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Studio1902\Peak\Commands;
+namespace Studio1902\PeakCommands\Commands;
 
 use Illuminate\Support\Facades\File;
 use Statamic\Support\Arr;

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Studio1902\Peak;
+namespace Studio1902\PeakCommands;
 
 use Statamic\Providers\AddonServiceProvider;
 


### PR DESCRIPTION
To be able to create more addons in the future, the namespace must be addon-specific.