### PR TITLE
Change rule from after to after_or_equal for exceptions

### DIFF
--- a/resources/stubs/presets/business_hours/business_hours_blueprint.yaml.stub
+++ b/resources/stubs/presets/business_hours/business_hours_blueprint.yaml.stub
@@ -175,7 +175,7 @@ tabs:
                     instructions_position: above
                     validate:
                       - required
-                      - 'after:{this}.start_date'
+                      - 'after_or_equal:{this}.start_date'
                     visibility: visible
               mode: table
               add_row: 'Add exception'


### PR DESCRIPTION
While reading [#15](https://github.com/studio1902/statamic-peak-commands/issues/15), it occurred to me that the rule for exceptions could be changed. 

Now the `end_date` must be at least one day after the `start_date`. The `after_or_equal` rule would add the ability to specify the same `start_date` as well

Changes proposed in this pull request:
- Change exception rule from `after` to `after_or_equal`
