### PR TITLE
Validate presets and blocks prompts

### DIFF
--- a/src/Commands/InstallBlock.php
+++ b/src/Commands/InstallBlock.php
@@ -25,7 +25,11 @@ class InstallBlock extends Command
         $this->choices = multiselect(
             label: 'Which blocks do you want to install into your page builder?',
             options: $this->getBlocks(),
-            scroll: 15
+            scroll: 15,
+            validate: fn ($values) => match (true) {
+                empty($values) => 'Please select at least one block. (Space)',
+                default => null,
+            }
         );
 
         foreach($this->choices as $choice) {

--- a/src/Commands/InstallPreset.php
+++ b/src/Commands/InstallPreset.php
@@ -38,7 +38,11 @@ class InstallPreset extends Command
             options: $this->presets->mapWithKeys(function ($preset, $key) {
                 return [$preset['handle'] => "{$preset['name']}: {$preset['description']}"];
             })->toArray(),
-            scroll: 15
+            scroll: 15,
+            validate: fn ($values) => match (true) {
+                empty($values) => 'Please select at least one preset. (Space)',
+                default => null,
+            }
         );
 
         $target = Storage::build([


### PR DESCRIPTION
Add validation messages for empty blocks and presets prompt selections. Fixes #17 

<img width="837" alt="Screenshot 2023-08-14 at 8 06 07 pm" src="https://github.com/studio1902/statamic-peak-commands/assets/414211/86bbfbb3-9cf8-436a-8177-8dab043d4d30">
