### PR TITLE
Fluid grid support

### DIFF
--- a/resources/stubs/block.antlers.html.stub
+++ b/resources/stubs/block.antlers.html.stub
@@ -5,7 +5,7 @@
 #}}
 
 <!-- /page_builder/_{{ filename }}.antlers.html -->
-<section class="fluid-container grid md:grid-cols-12 gap-8">
-    {{ partial:typography/h3 content="🔧<br>{{ name }}" class="md:col-span-12 text-center" }}
+<section class="fluid-grid">
+    {{ partial:typography/h3 content="🔧<br>{{ name }}" class="span-content text-center" }}
 </section>
 <!-- End: /page_builder/_{{ filename }}.antlers.html -->

--- a/resources/stubs/blocks/call_to_action.antlers.html.stub
+++ b/resources/stubs/blocks/call_to_action.antlers.html.stub
@@ -5,8 +5,8 @@
 #}}
 
 <!-- /page_builder/_call_to_action.antlers.html -->
-<section class="fluid-container grid md:grid-cols-12 gap-8">
-    <div class="md:col-start-3 md:col-span-8">
+<section class="fluid-grid">
+    <div class="span-content md:col-start-[col-3] md:col-span-8">
         {{ partial:typography/h2 class="mb-4" :content="block:title" }}
         {{ partial:typography/p class="mb-4" :content="block:text" }}
         {{ block:buttons ?= { partial:components/buttons } }}

--- a/resources/stubs/blocks/cards.antlers.html.stub
+++ b/resources/stubs/blocks/cards.antlers.html.stub
@@ -5,38 +5,40 @@
 #}}
 
 <!-- /page_builder/_cards.antlers.html -->
-<section class="fluid-container grid md:grid-cols-12 gap-8">
-    {{ block:title ?= { partial:typography/h2 :content="block:title" class="md:col-start-3 md:col-span-8 text-center" } }}
+<section class="fluid-grid">
+    <div class="span-content grid md:grid-cols-12 gap-fluid-grid-gap">
+        {{ block:title ?= { partial:typography/h2 :content="block:title" class="col-span-12 md:col-start-3 md:col-span-8 text-center" } }}
 
-    {{ block:cards }}
-        <{{ button ? 'a' : 'article' }}
-            class="
-                flex flex-col justify-between items-start p-6 border border-neutral/10 shadow-lg rounded no-underline focus:outline-none focus-visible:ring-2 ring-offset-2 ring-primary
-                {{ switch(
-                    (total_results === 1) => 'md:col-span-8 md:col-start-3',
-                    (total_results === 2) => 'md:col-span-6',
-                    (total_results > 2) => 'md:col-span-8 md:col-start-3 lg:col-span-4 lg:col-start-0',
-                    () => void
-                )}}
-            "
+        {{ block:cards }}
+            <{{ button ? 'a' : 'article' }}
+                class="
+                    flex flex-col justify-between items-start p-6 border border-neutral/10 shadow-lg rounded no-underline focus:outline-none focus-visible:ring-2 ring-offset-2 ring-primary
+                    {{ switch(
+                        (total_results === 1) => 'md:col-span-8 md:col-start-3',
+                        (total_results === 2) => 'md:col-span-6',
+                        (total_results > 2) => 'md:col-span-8 md:col-start-3 lg:col-span-4 lg:col-start-0',
+                        () => void
+                    )}}
+                "
+                    {{ button }}
+                        aria-labelledby="{{ title | slugify }}"
+                        draggable="false"
+                        {{ partial:statamic-peak-tools::snippets/button_attributes }}
+                    {{ /button }}
+            >
+                <div class="mb-4">
+                    <span id="{{ title | slugify }}">
+                        {{ partial:typography/h3 class="mb-2" color="text-neutral" :content="title" }}
+                    </span>
+                    {{ if text }}
+                        {{ partial:typography/p class="mb-4" :content="text" }}
+                    {{ /if }}
+                </div>
                 {{ button }}
-                    aria-labelledby="{{ title | slugify }}"
-                    draggable="false"
-                    {{ partial:statamic-peak-tools::snippets/button_attributes }}
+                    {{ partial:components/button as="span" faux="true" }}
                 {{ /button }}
-        >
-            <div class="mb-4">
-                <span id="{{ title | slugify }}">
-                    {{ partial:typography/h3 class="mb-2" color="text-neutral" :content="title" }}
-                </span>
-                {{ if text }}
-                    {{ partial:typography/p class="mb-4" :content="text" }}
-                {{ /if }}
-            </div>
-            {{ button }}
-                {{ partial:components/button as="span" faux="true" }}
-            {{ /button }}
-        </{{ button ? 'a' : 'article' }}>
-    {{ /block:cards }}
+            </{{ button ? 'a' : 'article' }}>
+        {{ /block:cards }}
+    </div>
 </section>
 <!-- End: /page_builder/_cards.antlers.html -->

--- a/resources/stubs/blocks/collection.antlers.html.stub
+++ b/resources/stubs/blocks/collection.antlers.html.stub
@@ -5,8 +5,8 @@
 #}}
 
 <!-- /page_builder/_collection.antlers.html -->
-<section class="fluid-container grid md:grid-cols-12 gap-8">
-    <div class="md:col-start-3 md:col-span-8">
+<section class="fluid-grid">
+    <div class="span-content md:col-start-[col-3] md:col-span-8">
         {{ partial:typography/h2 class="mb-4" :content="block:title" }}
         <ul class="list-inside list-disc">
             {{ block:collection }}

--- a/resources/stubs/blocks/columns.antlers.html.stub
+++ b/resources/stubs/blocks/columns.antlers.html.stub
@@ -5,38 +5,40 @@
 #}}
 
 <!-- /page_builder/_columns.antlers.html -->
-<section class="grid gap-6 fluid-container md:grid-cols-12">
-    {{ block:columns }}
-        <div
-            class="
-                {{ switch(
-                    (total_results == 1) => 'md:col-span-6 md:col-start-4',
-                    (total_results == 2) => 'md:col-span-6',
-                    (total_results >= 3) => 'md:col-span-4',
-                )}}
-            "
-        >
-            {{ partial
-                src="statamic-peak-tools::components/picture"
-                sizes="
-                    { switch(
-                        (total_results == 1) => '(min-width: 1280px) 1150px, 90vw',
-                        (total_results == 2) => '(min-width: 1280px) 640px, (min-width: 768px) 50vw, 90vw',
-                        (total_results >= 3) => '(min-width: 1280px) 430px, (min-width: 768px) 33vw, 90vw',
-                    )}
+<section class="fluid-grid">
+    <div class="span-content grid md:grid-cols-12 gap-fluid-grid-gap">
+        {{ block:columns }}
+            <div
+                class="
+                    {{ switch(
+                        (total_results == 1) => 'md:col-span-6 md:col-start-4',
+                        (total_results == 2) => 'md:col-span-6',
+                        (total_results >= 3) => 'md:col-span-4',
+                    )}}
                 "
-                aspect_ratio="{ total_results > 1 ?= 'large:4/3' }"
-                :image="image"
-                class="mb-6"
-                lazy="true"
-            }}
+            >
+                {{ partial
+                    src="statamic-peak-tools::components/picture"
+                    sizes="
+                        { switch(
+                            (total_results == 1) => '(min-width: 1280px) 1150px, 90vw',
+                            (total_results == 2) => '(min-width: 1280px) 640px, (min-width: 768px) 50vw, 90vw',
+                            (total_results >= 3) => '(min-width: 1280px) 430px, (min-width: 768px) 33vw, 90vw',
+                        )}
+                    "
+                    aspect_ratio="{ total_results > 1 ?= 'large:4/3' }"
+                    :image="image"
+                    class="mb-6"
+                    lazy="true"
+                }}
 
-            {{ partial:typography/prose as="div" class="{ buttons ?= 'mb-6' }" }}
-                {{ text }}
-            {{ /partial:typography/prose }}
+                {{ partial:typography/prose as="div" class="{ buttons ?= 'mb-6' }" }}
+                    {{ text }}
+                {{ /partial:typography/prose }}
 
-            {{ partial:components/buttons }}
-        </div>
-    {{ /block:columns }}
+                {{ partial:components/buttons }}
+            </div>
+        {{ /block:columns }}
+    </div>
 </section>
 <!-- End: /page_builder/_columns.antlers.html -->

--- a/resources/stubs/blocks/divider.antlers.html.stub
+++ b/resources/stubs/blocks/divider.antlers.html.stub
@@ -5,7 +5,7 @@
 #}}
 
 <!-- /page_builder/_divider.antlers.html -->
-<section class="fluid-container">
-    <hr class="border-b-1 border-neutral">
+<section class="fluid-grid">
+    <hr class="span-content border-b-1 border-neutral">
 </section>
 <!-- End: /page_builder/_divider.antlers.html -->

--- a/resources/stubs/blocks/full_width_image.antlers.html.stub
+++ b/resources/stubs/blocks/full_width_image.antlers.html.stub
@@ -5,20 +5,20 @@
 #}}
 
 <!-- /page_builder/_full_width_image.antlers.html -->
-<section class="relative w-full min-h-[14rem] py-12 md:py-16 lg:py-24">
-    <figure class="absolute inset-0">
+<section class="fluid-grid w-full min-h-[14rem]">
+    <figure class="row-start-1 span-full">
         {{ partial:statamic-peak-tools::components/picture :image="block:image" aspect_ratio="2/1 large:3/1" cover="true" lazy="true" sizes="100vw" }}
     </figure>
+
     {{ if block:title || block:text || block:buttons }}
-        <div class="absolute inset-0 bg-primary/80 mix-blend-multiply">
-        </div>
-    {{ /if }}
-    <div class="relative fluid-container grid md:grid-cols-12 gap-8">
-        <article class="md:col-span-8 md:col-start-3">
-            {{ title ?= { partial:typography/h2 :content="block:title" color="text-white" class="mb-4 text-center" } }}
-            {{ text ?= { partial:typography/p :content="block:text" color="text-white" class="text-center" } }}
-            {{ partial:components/buttons inverted="true" class="justify-center" }}
-        </article>
+    <div class="row-start-1 span-full inset-0 bg-primary/80 mix-blend-multiply" aria-hidden="true">
     </div>
+    {{ /if }}
+
+    <article class="row-start-1 isolate span-content md:col-start-[col-3] md:col-span-8 stack-4 py-12 md:py-16 lg:py-24">
+        {{ title ?= { partial:typography/h2 :content="block:title" color="text-white" class="text-center" } }}
+        {{ text ?= { partial:typography/p :content="block:text" color="text-white" class="text-center" } }}
+        {{ partial:components/buttons inverted="true" class="justify-center" }}
+    </article>
 </section>
 <!-- End: /page_builder/_full_width_image.antlers.html -->

--- a/resources/stubs/blocks/image_and_text.antlers.html.stub
+++ b/resources/stubs/blocks/image_and_text.antlers.html.stub
@@ -5,19 +5,19 @@
 #}}
 
 <!-- /page_builder/_image_and_text.antlers.html -->
-<section class="fluid-container grid md:grid-cols-12 gap-8 items-center">
-    <article class="md:col-span-6 {{ image_position == 'left' ?= 'order-2' }}">
-        {{ block:title ?= { partial:typography/h2 :content="block:title" class="mb-4" } }}
+<section class="fluid-grid gap-y-8 items-center grid-flow-col">
+    <article class="span-content md:col-span-6 stack-4 {{ image_position == 'left' ? 'md:col-start-[col-7]' : 'md:col-start-[content-start]' }}">
+        {{ block:title ?= { partial:typography/h2 :content="block:title" } }}
 
-        {{ partial:typography/prose class="{ buttons ?= 'mb-4' }" }}
+        {{ partial:typography/prose }}
             {{ block:text }}
         {{ /partial:typography/prose }}
 
         {{ partial:components/buttons }}
     </article>
 
-    <figure class="md:col-span-6">
-        {{ partial:statamic-peak-tools::components/picture :image="block:image" sizes="(min-width: 1280px) 640px, (min-width: 768px) 50vw, 90vw" }}
+    <figure class="span-content md:col-span-6 {{ image_position == 'left' ? 'md:col-start-[content-start]' : 'md:col-start-[col-7]' }}">
+        {{ partial:statamic-peak-tools::components/picture :image="block:image" cover="true" sizes="(min-width: 1280px) 640px, (min-width: 768px) 50vw, 90vw" }}
     </figure>
 </section>
 <!-- End: /page_builder/_image_and_text.antlers.html -->

--- a/resources/stubs/blocks/images_grid.antlers.html.stub
+++ b/resources/stubs/blocks/images_grid.antlers.html.stub
@@ -5,32 +5,34 @@
 #}}
 
 <!-- /page_builder/_images_grid.antlers.html -->
-<section class="grid gap-6 fluid-container md:grid-cols-12">
-    {{ block:rows }}
-        {{ images }}
-            <figure class="
-                {{ switch(
-                    (total_results == 1) => 'md:col-span-12',
-                    (total_results == 2) => 'md:col-span-6',
-                    (total_results == 3) => 'md:col-span-4',
-                )}}
-            ">
-                {{ partial
-                    src="statamic-peak-tools::components/picture"
-                    :image="url"
-                    sizes="
-                        { switch(
-                            (total_results == 1) => '(min-width: 1280px) 1150px, 90vw',
-                            (total_results == 2) => '(min-width: 1280px) 640px, (min-width: 768px) 50vw, 90vw',
-                            (total_results == 3) => '(min-width: 1280px) 430px, (min-width: 768px) 33vw, 90vw',
-                        )}
-                    "
-                    aspect_ratio="{ total_results > 1 ?= 'large:4/3' }"
-                    cover="{ total_results == 1 ? false : true }"
-                    lazy="true"
-                }}
-            </figure>
-        {{ /images }}
-    {{ /block:rows }}
+<section class="fluid-grid">
+    <div class="span-content grid md:grid-cols-12 gap-fluid-grid-gap">
+        {{ block:rows }}
+            {{ images }}
+                <figure class="
+                    {{ switch(
+                        (total_results == 1) => 'md:col-span-12',
+                        (total_results == 2) => 'md:col-span-6',
+                        (total_results == 3) => 'md:col-span-4',
+                    )}}
+                ">
+                    {{ partial
+                        src="statamic-peak-tools::components/picture"
+                        :image="url"
+                        sizes="
+                            { switch(
+                                (total_results == 1) => '(min-width: 1280px) 1150px, 90vw',
+                                (total_results == 2) => '(min-width: 1280px) 640px, (min-width: 768px) 50vw, 90vw',
+                                (total_results == 3) => '(min-width: 1280px) 430px, (min-width: 768px) 33vw, 90vw',
+                            )}
+                        "
+                        aspect_ratio="{ total_results > 1 ?= 'large:4/3' }"
+                        cover="{ total_results == 1 ? false : true }"
+                        lazy="true"
+                    }}
+                </figure>
+            {{ /images }}
+        {{ /block:rows }}
+    </div>
 </section>
 <!-- End: /page_builder/_images_grid.antlers.html -->

--- a/resources/stubs/blocks/text_columns.antlers.html.stub
+++ b/resources/stubs/blocks/text_columns.antlers.html.stub
@@ -5,12 +5,14 @@
 #}}
 
 <!-- /page_builder/_text_columns.antlers.html -->
-<section class="fluid-container">
-    {{ block:title ?= { partial:typography/h3 as="h2" :content="block:title" class="mb-2 md:max-w-[1/2]" } }}
+<section class="fluid-grid">
+    <div class="span-content">
+        {{ block:title ?= { partial:typography/h3 as="h2" :content="block:title" class="mb-2 md:max-w-[1/2]" } }}
 
-    {{ partial:typography/prose class="md:columns-2 gap-6 md:[&>ul]:inline-block md:[&>ul]:!mt-0 md:[&>ul]:mb-5 md:[&>ul]:break-inside-avoid md:[&>ol]:inline-block md:[&>ol]:!mt-0 md:[&>ol]:mb-5 md:[&>ol]:break-inside-avoid md:[&>p]:!mt-0
-    " }}
-        {{ block:text }}
-    {{ /partial:typography/prose }}
+        {{ partial:typography/prose class="md:columns-2 gap-6 md:[&>ul]:inline-block md:[&>ul]:!mt-0 md:[&>ul]:mb-5 md:[&>ul]:break-inside-avoid md:[&>ol]:inline-block md:[&>ol]:!mt-0 md:[&>ol]:mb-5 md:[&>ol]:break-inside-avoid md:[&>p]:!mt-0
+        " }}
+            {{ block:text }}
+        {{ /partial:typography/prose }}
+    </div>
 </section>
 <!-- End: /page_builder/_text_columns.antlers.html -->

--- a/resources/stubs/index.antlers.html.stub
+++ b/resources/stubs/index.antlers.html.stub
@@ -13,21 +13,23 @@
 
 {{ section:index_content }}
     <!-- /{{ filename }}/index.antlers.html -->
-    <div class="fluid-container grid md:grid-cols-12 gap-12">
-        {{ collection:{{ handle }} sort="{{ sort }}" paginate="true" limit="10" as="items" }}
-            {{ unless no_results }}
-                {{ items }}
-                    <div class="md:col-span-6">
-                        <a class="underline" href="{{ url }}">{{ title }}</a>
+    <section class="fluid-grid">
+        <div class="span-content grid grid-cols-12 gap-fluid-grid-gap">
+            {{ collection:{{ handle }} sort="{{ sort }}" paginate="true" limit="10" as="items" }}
+                {{ unless no_results }}
+                    {{ items }}
+                        <div class="col-span-12 md:col-span-6">
+                            <a class="underline" href="{{ url }}">{{ title }}</a>
+                        </div>
+                    {{ /items }}
+                {{ else }}
+                    <div class="col-span-12">
+                        {{ trans:strings.no_results }}
                     </div>
-                {{ /items }}
-            {{ else }}
-                <div class="md:col-span-6">
-                    {{ trans:strings.no_results }}
-                </div>
-            {{ /unless }}
-            {{ partial:statamic-peak-tools::components/pagination class="md:col-span-12" }}
-        {{ /collection:{{ handle }} }}
-    </div>
+                {{ /unless }}
+                {{ partial:statamic-peak-tools::components/pagination class="col-span-12" }}
+            {{ /collection:{{ handle }} }}
+        </div>
+    </section>
     <!-- End: /{{ filename }}/index.antlers.html -->
 {{ /section:index_content }}

--- a/resources/stubs/presets/clients/clients.antlers.html.stub
+++ b/resources/stubs/presets/clients/clients.antlers.html.stub
@@ -5,19 +5,21 @@
 #}}
 
 <!-- /page_builder/_{{ handle }}.antlers.html -->
-<section class="fluid-container grid grid-cols-2 md:grid-cols-10 gap-12 place-items-center">
-    {{ block:title ?= { partial:typography/h2 :content="block:title" class="col-span-2 md:col-span-12" } }}
+<section class="fluid-grid">
+    <div class="span-content grid grid-cols-2 md:grid-cols-10 gap-12 place-items-center">
+        {{ block:title ?= { partial:typography/h2 :content="block:title" class="col-span-2 md:col-span-12" } }}
 
-    {{
-        {{ handle }} = block:{{ handle }}
-            ? block:{{ handle }}
-            : { collection:{{ handle }} sort="order" }
-    }}
+        {{
+            {{ handle }} = block:{{ handle }}
+                ? block:{{ handle }}
+                : { collection:{{ handle }} sort="order" }
+        }}
 
-    {{ {{ handle }} }}
-        <a class="md:col-span-2 p-1 -m-1 hover:scale-105 motion-safe:transition-transform focus:outline-none focus-visible:ring-2 focus-visible:ring-primary group" href="{{ website }}" target="_blank" rel="noopener" aria-label="{{ title }}">
-            {{ partial:statamic-peak-tools::components/picture :image="logo" class="grayscale group-focus-visible:grayscale-0 group-hover:grayscale-0 motion-safe:transition" }}
-        </a>
-    {{ /{{ handle }} }}
+        {{ {{ handle }} }}
+            <a class="md:col-span-2 p-1 -m-1 hover:scale-105 motion-safe:transition-transform focus:outline-none focus-visible:ring-2 focus-visible:ring-primary group" href="{{ website }}" target="_blank" rel="noopener" aria-label="{{ title }}">
+                {{ partial:statamic-peak-tools::components/picture :image="logo" class="grayscale group-focus-visible:grayscale-0 group-hover:grayscale-0 motion-safe:transition" }}
+            </a>
+        {{ /{{ handle }} }}
+    </div>
 </section>
 <!-- End: /page_builder/_{{ handle }}.antlers.html -->

--- a/resources/stubs/presets/events/events.antlers.html.stub
+++ b/resources/stubs/presets/events/events.antlers.html.stub
@@ -5,23 +5,25 @@
 #}}
 
 <!-- /page_builder/_{{ handle }}.antlers.html -->
-<section class="fluid-container grid md:grid-cols-12 gap-8">
-    {{ title ?= { partial:typography/h1 as="h2" :content="title" class="md:col-span-12" } }}
+<section class="fluid-grid">
+    <div class="span-content grid md:grid-cols-12 gap-fluid-grid-gap">
+        {{ title ?= { partial:typography/h1 as="h2" :content="title" class="md:col-span-12" } }}
 
-    {{ collection:{{ handle }} sort="{{ singular_handle }}_date_start:asc" {{ singular_handle }}_date_end:is_after="{ today | modify_date('+1 day') }" limit="3" as="items" }}
-        {{ unless no_results }}
-            {{ items }}
-                {{ partial:components/{{ handle }}_item class="md:col-span-4" }}
-            {{ /items }}
-        {{ else }}
-            <div class="md:col-span-6">
-                {{ trans:strings.no_results }}
-            </div>
-        {{ /unless }}
-    {{ /collection:{{ handle }} }}
+        {{ collection:{{ handle }} sort="{{ singular_handle }}_date_start:asc" {{ singular_handle }}_date_end:is_after="{ today | modify_date('+1 day') }" limit="3" as="items" }}
+            {{ unless no_results }}
+                {{ items }}
+                    {{ partial:components/{{ handle }}_item class="md:col-span-4" }}
+                {{ /items }}
+            {{ else }}
+                <div class="md:col-span-6">
+                    {{ trans:strings.no_results }}
+                </div>
+            {{ /unless }}
+        {{ /collection:{{ handle }} }}
 
-    <nav class="md:col-span-12 text-right">
-        {{ partial:components/button label="{trans:strings.{{ handle }}_all}" button_type="inline" link_type="url" url="{mount_url:{{ handle }}}" }}
-    </nav>
+        <nav class="md:col-span-12 text-right">
+            {{ partial:components/button label="{trans:strings.{{ handle }}_all}" button_type="inline" link_type="url" url="{mount_url:{{ handle }}}" }}
+        </nav>
+    </div>
 </section>
 <!-- End: /page_builder/_{{ handle }}.antlers.html -->

--- a/resources/stubs/presets/events/index.antlers.html.stub
+++ b/resources/stubs/presets/events/index.antlers.html.stub
@@ -13,21 +13,23 @@
 
 {{ section:index_content }}
     <!-- /{{ handle }}/index.antlers.html -->
-    <div class="fluid-container grid md:grid-cols-12 gap-8">
-        {{ partial:typography/h1 as="h2" :content="title" class="md:col-span-12" }}
-        {{ collection:{{ handle }} sort="{{ singular_handle }}_date_start:asc" {{ singular_handle }}_date_end:is_after="{ today }" paginate="true" limit="12" as="items" }}
-            {{ unless no_results }}
-                {{ items }}
-                    {{ partial:components/{{ handle }}_item class="md:col-span-4" }}
-                {{ /items }}
-            {{ else }}
-                <div class="md:col-span-6">
-                    {{ trans:strings.no_results }}
-                </div>
-            {{ /unless }}
+    <section class="fluid-grid">
+        <div class="span-content grid md:grid-cols-12 gap-fluid-grid-gap">
+            {{ partial:typography/h1 as="h2" :content="title" class="md:col-span-12" }}
+            {{ collection:{{ handle }} sort="{{ singular_handle }}_date_start:asc" {{ singular_handle }}_date_end:is_after="{ today }" paginate="true" limit="12" as="items" }}
+                {{ unless no_results }}
+                    {{ items }}
+                        {{ partial:components/{{ handle }}_item class="md:col-span-4" }}
+                    {{ /items }}
+                {{ else }}
+                    <div class="md:col-span-6">
+                        {{ trans:strings.no_results }}
+                    </div>
+                {{ /unless }}
 
-            {{ partial:statamic-peak-tools::components/pagination class="md:col-span-12" }}
-        {{ /collection:{{ handle }} }}
-    </div>
+                {{ partial:statamic-peak-tools::components/pagination class="md:col-span-12" }}
+            {{ /collection:{{ handle }} }}
+        </div>
+    </section>
     <!-- End: /{{ handle }}/index.antlers.html -->
 {{ /section:index_content }}

--- a/resources/stubs/presets/events/show.antlers.html.stub
+++ b/resources/stubs/presets/events/show.antlers.html.stub
@@ -42,16 +42,16 @@
 </script>
 
 <main class="py-12 md:py-16 lg:py-24 stack-12 md:stack-16 lg:stack-24" id="content">
-    <section class="fluid-container grid md:grid-cols-12 gap-8 lg:-mb-12">
-        <header class="md:col-span-8 md:col-start-3">
+    <section class="fluid-grid stack-8">
+        <header class="md:col-start-[col-3] md:col-span-8 stack-4">
             {{ partial:typography/h1 :content="title" class="mt-4 text-center" }}
 
-            <figure class="mt-4">
+            <figure>
                 {{ partial:statamic-peak-tools::components/picture :image="image" sizes="(min-width: 1280px) 1150px, (min-width: 768px) 90vw" aspect_ratio="3/1" lazy="true" cover="true" class="aspect-[3/1]" }}
             </figure>
         </header>
 
-        <aside class="size-md p-6 md:p-8 grid md:grid-cols-3 gap-2 md:gap-8 border border-neutral/10 shadow-lg rounded">
+        <aside class="md:col-start-[col-3] md:col-span-8 p-6 md:p-8 grid md:grid-cols-3 gap-2 md:gap-8 border border-neutral/10 shadow-lg rounded">
             {{ partial:typography/h3 content="{trans:strings.{{ handle }}_when}" }}
             <time class="md:col-span-2 mb-4 md:mb-0" lang="{{ site:short_locale }}">
                 {{ partial:typography/time as="span" :content="{{ singular_handle }}_date_start" }}
@@ -92,12 +92,14 @@
 
     {{ collection:{{ handle }} sort="{{ singular_handle }}_date_start:asc" {{ singular_handle }}_date_end:is_after="{ today }" :id:isnt="id" limit="3" as="items" }}
         {{ unless no_results }}
-            <section class="fluid-container grid md:grid-cols-12 gap-8">
-                {{ partial:typography/h1 as="h2" content="{ trans:strings.{{ handle }}_more }" class="md:col-span-12" }}
+            <section class="fluid-grid">
+                <div class="span-content grid md:grid-cols-12 gap-fluid-grid-gap">
+                    {{ partial:typography/h1 as="h2" content="{ trans:strings.{{ handle }}_more }" class="md:col-span-12" }}
 
-                {{ items }}
-                    {{ partial:components/{{ handle }}_item class="md:col-span-4" }}
-                {{ /items }}
+                    {{ items }}
+                        {{ partial:components/{{ handle }}_item class="md:col-span-4" }}
+                    {{ /items }}
+                </div>
             </section>
         {{ /unless }}
     {{ /collection:{{ handle }} }}

--- a/resources/stubs/presets/faq/faq.antlers.html.stub
+++ b/resources/stubs/presets/faq/faq.antlers.html.stub
@@ -19,9 +19,9 @@
     </script>
 {{ /once }}
 
-<section class="fluid-container grid md:grid-cols-12 gap-8">
+<section class="fluid-grid stack-8">
     {{ if block:title || block:text }}
-        <header class="md:col-span-8 md:col-start-3">
+        <header class="span-content md:col-start-[col-3] md:col-span-8">
             {{ block:title ?= { partial:typography/h1 as="h2" :content="block:title" class="mb-4" } }}
             {{ block:text ?= { partial:typography/p :content="block:text" } }}
         </header>
@@ -29,7 +29,7 @@
 
     <div
         x-data="{ expanded: null }"
-        class="md:col-span-8 md:col-start-3 flex flex-col gap-4"
+        class="span-content md:col-start-[col-3] md:col-span-8 flex flex-col gap-4"
     >
         {{ block:questions }}
             {{ partial:components/question }}

--- a/resources/stubs/presets/image_credits/image_credits.antlers.html.stub
+++ b/resources/stubs/presets/image_credits/image_credits.antlers.html.stub
@@ -5,29 +5,31 @@
 #}}
 
 <!-- /page_builder/_image_credits.antlers.html -->
-<section class="fluid-container grid grid-cols-2 md:grid-cols-12 gap-4 md:gap-8">
+<section class="fluid-grid">
     {{ if block:title || block:text }}
-        <header class="col-span-2 md:col-span-8 md:col-start-3 text-center flex flex-col items-center">
-            {{ block:title ?= { partial:typography/h2 class="mb-4" :content="block:title" } }}
-            {{ block:text ?= { partial:typography/p class="mb-4" :content="block:text" } }}
+        <header class="span-content text-center stack-4">
+            {{ block:title ?= { partial:typography/h2 :content="block:title" } }}
+            {{ block:text ?= { partial:typography/p :content="block:text" } }}
         </header>
     {{ /if }}
 
-    {{ assets container="images" as="images" }}
-        {{ images where (copyright.name !== null) orderby (copyright.name 'asc') }}
-            <figure class="md:col-span-3">
-                <div class="aspect-square">
-                    {{ partial:statamic-peak-tools::components/picture :image="url" sizes="(min-width: 1280px) 1280px, (min-width: 768px) 20vw, 50vw" aspect_ratio="1/1" cover="true" }}
-                </div>
-                <figcaption class="mt-4">
-                    {{ if copyright:url }}
-                        {{ partial:components/button :label="copyright:name" button_type="inline" link_type="url" :url="copyright:url" target_blank="true" }}
-                    {{ else }}
-                        {{ copyright:name }}
-                    {{ /if  }}
-                </figcaption>
-            </figure>
-        {{ /images }}
-    {{ /assets }}
+    <div class="span-content grid grid-cols-2 md:grid-cols-12 gap-4 md:gap-8">
+        {{ assets container="images" as="images" }}
+            {{ images where (copyright.name !== null) orderby (copyright.name 'asc') }}
+                <figure class="md:col-span-3">
+                    <div class="aspect-square">
+                        {{ partial:statamic-peak-tools::components/picture :image="url" sizes="(min-width: 1280px) 1280px, (min-width: 768px) 20vw, 50vw" aspect_ratio="1/1" cover="true" }}
+                    </div>
+                    <figcaption class="mt-4">
+                        {{ if copyright:url }}
+                            {{ partial:components/button :label="copyright:name" button_type="inline" link_type="url" :url="copyright:url" target_blank="true" }}
+                        {{ else }}
+                            {{ copyright:name }}
+                        {{ /if  }}
+                    </figcaption>
+                </figure>
+            {{ /images }}
+        {{ /assets }}
+    </div>
 </section>
 <!-- End: /page_builder/_image_credits.antlers.html -->

--- a/resources/stubs/presets/image_credits/images_blueprint.yaml.stub
+++ b/resources/stubs/presets/image_credits/images_blueprint.yaml.stub
@@ -9,6 +9,7 @@ sections:
           display: 'Alt Text'
           type: textarea
           instructions: 'Description of the image'
+          focus: true
       -
         handle: copyright
         field:

--- a/resources/stubs/presets/news/index.antlers.html.stub
+++ b/resources/stubs/presets/news/index.antlers.html.stub
@@ -13,21 +13,23 @@
 
 {{ section:index_content }}
     <!-- /{{ handle }}/index.antlers.html -->
-    <div class="fluid-container grid md:grid-cols-12 gap-8">
-        {{ partial:typography/h1 :content="title" class="md:col-span-12" }}
-        {{ collection:{{ handle }} sort="date:desc" paginate="true" limit="12" as="items" }}
-            {{ unless no_results }}
-                {{ items }}
-                    {{ partial:components/{{ handle }}_item class="md:col-span-4" }}
-                {{ /items }}
-            {{ else }}
-                <div class="md:col-span-6">
-                    {{ trans:strings.no_results }}
-                </div>
-            {{ /unless }}
+    <section class="fluid-grid">
+        <div class="span-content grid md:grid-cols-12 gap-fluid-grid-gap">
+            {{ partial:typography/h1 as="h2" :content="title" class="md:col-span-12" }}
+            {{ collection:{{ handle }} sort="date:desc" paginate="true" limit="12" as="items" }}
+                {{ unless no_results }}
+                    {{ items }}
+                        {{ partial:components/{{ handle }}_item class="md:col-span-4" }}
+                    {{ /items }}
+                {{ else }}
+                    <div class="md:col-span-6">
+                        {{ trans:strings.no_results }}
+                    </div>
+                {{ /unless }}
 
-            {{ partial:statamic-peak-tools::components/pagination class="md:col-span-12" }}
-        {{ /collection:{{ handle }} }}
-    </div>
+                {{ partial:statamic-peak-tools::components/pagination class="md:col-span-12" }}
+            {{ /collection:{{ handle }} }}
+        </div>
+    </section>
     <!-- End: /{{ handle }}/index.antlers.html -->
 {{ /section:index_content }}

--- a/resources/stubs/presets/news/news.antlers.html.stub
+++ b/resources/stubs/presets/news/news.antlers.html.stub
@@ -5,23 +5,25 @@
 #}}
 
 <!-- /page_builder/_{{ handle }}.antlers.html -->
-<section class="fluid-container grid md:grid-cols-12 gap-8">
-    {{ title ?= { partial:typography/h1 as="h2" :content="title" class="md:col-span-12" } }}
+<section class="fluid-grid">
+    <div class="span-content grid md:grid-cols-12 gap-fluid-grid-gap">
+        {{ title ?= { partial:typography/h1 as="h2" :content="title" class="md:col-span-12" } }}
 
-    {{ collection:{{ handle }} sort="date:desc" limit="3" as="items" }}
-        {{ unless no_results }}
-            {{ items }}
-                {{ partial:components/{{ handle }}_item class="md:col-span-4" }}
-            {{ /items }}
-        {{ else }}
-            <div class="md:col-span-6">
-                {{ trans:strings.no_results }}
-            </div>
-        {{ /if }}
-    {{ /collection:{{ handle }} }}
+        {{ collection:{{ handle }} sort="date:desc" limit="3" as="items" }}
+            {{ unless no_results }}
+                {{ items }}
+                    {{ partial:components/{{ handle }}_item class="md:col-span-4" }}
+                {{ /items }}
+            {{ else }}
+                <div class="md:col-span-6">
+                    {{ trans:strings.no_results }}
+                </div>
+            {{ /if }}
+        {{ /collection:{{ handle }} }}
 
-    <nav class="md:col-span-12 text-right">
-        {{ partial:components/button label="{trans:strings.{{ handle }}_all}" button_type="inline" link_type="url" url="{mount_url:{{ handle }}}" }}
-    </nav>
+        <nav class="md:col-span-12 text-right">
+            {{ partial:components/button label="{trans:strings.{{ handle }}_all}" button_type="inline" link_type="url" url="{mount_url:{{ handle }}}" }}
+        </nav>
+    </div>
 </section>
 <!-- End: /page_builder/_{{ handle }}.antlers.html -->

--- a/resources/stubs/presets/news/show.antlers.html.stub
+++ b/resources/stubs/presets/news/show.antlers.html.stub
@@ -30,20 +30,21 @@
         }
     }
 </script>
+
 <main class="py-12 md:py-16 lg:py-24 stack-12 md:stack-16 lg:stack-24" id="content">
-    <div class="fluid-container grid md:grid-cols-12 gap-8 lg:-mb-12">
-        <header class="md:col-span-8 md:col-start-3">
+    <div class="fluid-grid stack-8">
+        <header class="md:col-start-[col-3] md:col-span-8 stack-4">
             {{ partial:typography/time :content="date" class="block text-center" }}
 
-            {{ partial:typography/h1 :content="title" class="mt-4 text-center" }}
+            {{ partial:typography/h1 :content="title" class="text-center" }}
 
-            <figure class="mt-4">
+            <figure>
                 {{ partial:statamic-peak-tools::components/picture :image="image" sizes="(min-width: 1280px) 1150px, (min-width: 768px) 90vw" aspect_ratio="3/2" lazy="true" cover="true" class="aspect-[3/2]" }}
             </figure>
         </header>
     </div>
 
-    <section class="fluid-container grid grid-cols-12">
+    <section class="fluid-grid">
         {{ partial:typography/prose as="article" class="contents" }}
             {{ article }}
                 {{ partial src="components/{type}" }}
@@ -53,12 +54,14 @@
 
     {{ collection:previous in="{{ handle }}" sort="date:asc" limit="3" as="items" }}
         {{ unless no_results }}
-            <section class="fluid-container grid md:grid-cols-12 gap-8">
-                {{ partial:typography/h1 as="h2" content="{ trans:strings.{{ handle }}_more }" class="md:col-span-12" }}
+            <section class="fluid-grid">
+                <div class="span-content grid md:grid-cols-12 gap-fluid-grid-gap">
+                    {{ partial:typography/h1 as="h2" content="{ trans:strings.{{ handle }}_more }" class="md:col-span-12" }}
 
-                {{ items }}
-                    {{ partial:components/{{ handle }}_item class="md:col-span-4" }}
-                {{ /items }}
+                    {{ items }}
+                        {{ partial:components/{{ handle }}_item class="md:col-span-4" }}
+                    {{ /items }}
+                </div>
             </section>
         {{ /unless }}
     {{ /collection:previous }}

--- a/resources/stubs/presets/search/search.antlers.html.stub
+++ b/resources/stubs/presets/search/search.antlers.html.stub
@@ -10,12 +10,12 @@
 
 <!-- /search.antlers.html -->
 <main class="py-12 md:py-16 lg:py-24 stack-12 md:stack-16 lg:stack-24" id="content">
-    <section class="fluid-container grid grid-cols-12 gap-y-6">
-        <div class="col-span-12 md:col-span-8 md:col-start-3">
+    <section class="fluid-grid stack-6">
+        <div class="span-content md:col-start-[col-3] md:col-span-8">
             {{ partial:typography/h1 class="mb-2" content="{trans:strings.search_results_for} &OpenCurlyDoubleQuote;<span class='italic'>{get:q}</span>&CloseCurlyDoubleQuote;" }}
         </div>
 
-        <form class="relative col-span-12 md:col-span-8 md:col-start-3" action="/search" role="search">
+        <form class="relative span-content md:col-start-[col-3] md:col-span-8" action="/search" role="search">
             <input class="w-full pr-10 rounded border-neutral focus-visible:border-primary focus-visible:ring focus-visible:ring-primary motion-safe:transition" placeholder="{{ trans:strings.search }}" type="search" value="{{ get:q }}" name="q"/>
 
             <button class="absolute inset-y-0 right-0 flex mr-1 items-center text-neutral hover:text-primary rounded focus:outline-none focus-visible:ring-2 ring-secondary ring-offset-4 ring-offset-white" aria-label="{{ trans:strings.search }}">
@@ -25,11 +25,11 @@
 
         {{ search:results }}
             {{ if no_results }}
-                <article class="col-span-12 md:col-span-8 md:col-start-3">
+                <article class="span-content md:col-start-[col-3] md:col-span-8">
                     {{ partial:typography/p content="{trans:strings.search_no_results}" }}
                 </article>
             {{ else }}
-                <article class="col-span-12 md:col-span-8 md:col-start-3">
+                <article class="span-content md:col-start-[col-3] md:col-span-8">
                     <a class="flex flex-col" href="{{ url }}">
                         <span class="text-neutral underline decoration-primary mb-1 break-words">{{ permalink }}</span>
 

--- a/resources/stubs/presets/team_members/team_members.antlers.html.stub
+++ b/resources/stubs/presets/team_members/team_members.antlers.html.stub
@@ -5,15 +5,15 @@
 #}}
 
 <!-- /page_builder/_{{ handle }}.antlers.html -->
-<section class="fluid-container grid md:grid-cols-12 gap-8">
+<section class="fluid-grid gap-y-8">
     {{ if block:title or block:text }}
-        <header class="md:col-span-6">
-            {{ block:title ?= { partial:typography/h2 :content="block:title" class="mb-4" } }}
+        <header class="span-content stack-4">
+            {{ block:title ?= { partial:typography/h2 :content="block:title" } }}
             {{ block:text ?= { partial:typography/p :content="block:text" } }}
         </header>
     {{ /if }}
 
-    <div class="md:col-span-12 grid md:grid-cols-12 gap-8">
+    <div class="span-content grid md:grid-cols-12 gap-fluid-grid-gap">
         {{
             {{ handle }} = block:{{ handle }}
                 ? block:{{ handle }}

--- a/resources/stubs/presets/vacancies/index.antlers.html.stub
+++ b/resources/stubs/presets/vacancies/index.antlers.html.stub
@@ -13,20 +13,22 @@
 
 {{ section:index_content }}
     <!-- /{{ handle }}/index.antlers.html -->
-    <div class="fluid-container grid md:grid-cols-12 gap-12">
-        {{ collection:{{ handle }} sort="date:desc" paginate="true" limit="12" as="items" expires:is_after="{today}" }}
-            {{ unless no_results }}
-                {{ items }}
-                    {{ partial:components/{{ handle }}_item class="md:col-span-6" }}
-                {{ /items }}
-            {{ else }}
-                <div class="md:col-span-6">
-                    {{ trans:strings.no_results }}
-                </div>
-            {{ /unless }}
-            {{ partial:statamic-peak-tools::components/pagination class="md:col-span-12" }}
-        {{ /collection:{{ handle }} }}
-    </div>
+    <section class="fluid-grid">
+        <div class="span-content grid md:grid-cols-12 gap-fluid-grid-gap">
+            {{ collection:{{ handle }} sort="date:desc" paginate="true" limit="12" as="items" expires:is_after="{today}" }}
+                {{ unless no_results }}
+                    {{ items }}
+                        {{ partial:components/{{ handle }}_item class="md:col-span-6" }}
+                    {{ /items }}
+                {{ else }}
+                    <div class="md:col-span-6">
+                        {{ trans:strings.no_results }}
+                    </div>
+                {{ /unless }}
+                {{ partial:statamic-peak-tools::components/pagination class="md:col-span-12" }}
+            {{ /collection:{{ handle }} }}
+        </div>
+    </section>
     <!-- End: /{{ handle }}/index.antlers.html -->
 {{ /section:index_content }}
 <!-- End: /{{ handle }}/index.antlers.html -->

--- a/resources/stubs/presets/vacancies/show.antlers.html.stub
+++ b/resources/stubs/presets/vacancies/show.antlers.html.stub
@@ -43,14 +43,14 @@
 </script>
 
 <main class="py-12 md:py-16 lg:py-24 stack-12 md:stack-16 lg:stack-24" id="content">
-    <section class="fluid-container grid md:grid-cols-12 gap-12">
-        {{ partial:typography/h1 :content="title" class="md:col-span-12" }}
+    <section class="fluid-grid stack-12">
+        {{ partial:typography/h1 :content="title" class="span-content" }}
 
-        <div class="md:col-span-6">
+        <div class="span-content md:col-start-[col-1] md:col-span-6">
             {{ partial:typography/p :content="teaser" }}
         </div>
 
-         <aside class="md:col-span-6">
+         <aside class="span-content md:col-start-[col-1] md:col-span-6">
             {{ trans:strings.{{ handle }}_published }}: {{ partial:typography/time :content="date" }}<br>
             {{ trans:strings.{{ handle }}_expires }}: {{ partial:typography/time :content="expires" }}<br>
             {{ trans:strings.{{ handle }}_region }}: {{ region }}<br>

--- a/resources/stubs/show.antlers.html.stub
+++ b/resources/stubs/show.antlers.html.stub
@@ -5,8 +5,10 @@
 
 <!-- /{{ filename }}/show.antlers.html -->
 <main class="py-12 md:py-16 lg:py-24 stack-12 md:stack-16 lg:stack-24" id="content">
-    <div class="fluid-container">
-        {{ partial:typography/h1 :content="title" }}
+    <div class="fluid-grid">
+        <div class="span-content">
+            {{ partial:typography/h1 :content="title" }}
+        </div>
     </div>
 
     {{ page_builder scope="block" }}

--- a/resources/stubs/show.antlers.html.stub
+++ b/resources/stubs/show.antlers.html.stub
@@ -5,11 +5,9 @@
 
 <!-- /{{ filename }}/show.antlers.html -->
 <main class="py-12 md:py-16 lg:py-24 stack-12 md:stack-16 lg:stack-24" id="content">
-    <div class="fluid-grid">
-        <div class="span-content">
-            {{ partial:typography/h1 :content="title" }}
-        </div>
-    </div>
+    <header class="fluid-grid">
+        {{ partial:typography/h1 :content="title" class="span-content" }}
+    </header>
 
     {{ page_builder scope="block" }}
         {{ partial src="page_builder/{type}" }}


### PR DESCRIPTION
Updates all stubs to use `fluid-grid` instead of `fluid-container`.

Goes with: https://github.com/studio1902/statamic-peak/pull/373