### PR TITLE
Add singular names to the presets with type "rename"

### DIFF
--- a/src/Commands/InstallPreset.php
+++ b/src/Commands/InstallPreset.php
@@ -105,13 +105,13 @@ class InstallPreset extends Command
                     $this->rename = true;
                     $this->rename_name = text(
                         label: "What should be the collection name for '{$preset['name']}'?",
-                        placeholder: "E.g. Events",
+                        placeholder: "E.g. '{$preset['name']}'",
                         required: true
                     );
                     $this->rename_handle = Str::slug($this->rename_name, '_');
                     $this->rename_singular_name = ucfirst(text(
                         label: "What is the singular name for this '{$this->rename_name}' collection?",
-                        placeholder: "E.g. Event",
+                        placeholder: "E.g. '{$preset['singular_name']}'",
                         required: true
                     ));
                     $this->rename_singular_handle = Str::slug($this->rename_singular_name, '_');

--- a/src/Commands/InstallPresetPresets.php
+++ b/src/Commands/InstallPresetPresets.php
@@ -105,6 +105,7 @@ trait InstallPresetPresets {
             [
                 'handle' => 'clients',
                 'name' => 'Clients',
+                'singular_name' => 'Client',
                 'description' => 'A renamable client/partner collection.',
                 'operations' => [
                     [
@@ -157,6 +158,7 @@ trait InstallPresetPresets {
             [
                 'handle' => 'events',
                 'name' => 'Events',
+                'singular_name' => 'Event',
                 'description' => 'A dated renamable events collection.',
                 'operations' => [
                     [
@@ -381,6 +383,7 @@ trait InstallPresetPresets {
             [
                 'handle' => 'news',
                 'name' => 'News',
+                'singular_name' => 'Item',
                 'description' => 'A dated renamable news/blog collection with feed.',
                 'operations' => [
                     [
@@ -663,6 +666,7 @@ trait InstallPresetPresets {
             [
                 'handle' => 'team_members',
                 'name' => 'Team members',
+                'singular_name' => 'Member',
                 'description' => 'A renamable team member collection.',
                 'operations' => [
                     [
@@ -731,6 +735,7 @@ trait InstallPresetPresets {
             [
                 'handle' => 'vacancies',
                 'name' => 'Vacancies',
+                'singluar_name' => 'Vacancy',
                 'description' => 'A dated renamable vacancies collection.',
                 'operations' => [
                     [


### PR DESCRIPTION
PR for this [idea](https://github.com/studio1902/statamic-peak-commands/discussions/24)

Changes proposed in this pull request:
- Add singular name to each preset with type "rename"
- Show dynamic plural and singular names in the CLI


(Did it on github.com, so there was a third commit that merged the patch and main branch from my fork. Sorry Rob!)
