### PR TITLE
Fix business hours logic for overnight spans

### DIFF
--- a/resources/stubs/presets/business_hours/business_hours_snippet.antlers.html.stub
+++ b/resources/stubs/presets/business_hours/business_hours_snippet.antlers.html.stub
@@ -8,38 +8,83 @@
     <script>
         document.addEventListener('alpine:init', () => {
             Alpine.data('businessHours', () => ({
-                now: Math.floor(Date.now() / 1000),
-                businessHours:  JSON.parse('{{ (business_hours:dates ?? false) | to_json }}'),
+                businessHours: JSON.parse('{{ (business_hours:dates ?? false) | to_json }}'),
                 exceptions: JSON.parse('{{ (business_hours:exceptions ?? false) | to_json }}'),
                 weekDays: ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'],
                 currentWeekDay: null,
                 businessHoursToday: null,
-                closed: null,
-                open: null,
-                startTime: null,
-                endTime: null,
-                localTime: null,
+                closed: true,
+                open: false,
+                timeToMinutes(timeStr) {
+                    const [hours, minutes] = timeStr.split(':').map(Number);
+                    return hours * 60 + minutes;
+                },
+                getCurrentMinutes() {
+                    const now = new Date();
+                    return now.getHours() * 60 + now.getMinutes();
+                },
+                spansMidnight(startTime, endTime) {
+                    const startMinutes = this.timeToMinutes(startTime);
+                    const endMinutes = this.timeToMinutes(endTime);
+                    return endMinutes < startMinutes;
+                },
+                getBusinessHours(weekday) {
+                    return this.businessHours.find(day => day.weekday.value === weekday);
+                },
+                getPreviousWeekday(weekday) {
+                    const idx = this.weekDays.indexOf(weekday);
+                    return this.weekDays[(idx - 1 + 7) % 7];
+                },
+                checkIfOpen() {
+                    if (this.exceptions !== false) {
+                        const now = new Date().getTime() / 1000;
+                        const activeException = this.exceptions.find(exception => 
+                            exception.active === true &&
+                            new Date(exception.start_date).getTime() / 1000 <= now &&
+                            new Date(exception.end_date).getTime() / 1000 >= now
+                        );
+                        if (activeException) {
+                            return false;
+                        }
+                    }
+
+                    const currentMinutes = this.getCurrentMinutes();
+
+                    const yesterdayWeekday = this.getPreviousWeekday(this.currentWeekDay);
+                    const yesterdayHours = this.getBusinessHours(yesterdayWeekday);
+                    
+                    if (yesterdayHours?.open) {
+                        const startMinutes = this.timeToMinutes(yesterdayHours.start_time);
+                        const endMinutes = this.timeToMinutes(yesterdayHours.end_time);
+                        
+                        if (this.spansMidnight(yesterdayHours.start_time, yesterdayHours.end_time)) {
+                            if (currentMinutes <= endMinutes) {
+                                return true;
+                            }
+                        }
+                    }
+
+                    if (this.businessHoursToday?.open) {
+                        const startMinutes = this.timeToMinutes(this.businessHoursToday.start_time);
+                        const endMinutes = this.timeToMinutes(this.businessHoursToday.end_time);
+                        const spansOvernight = this.spansMidnight(this.businessHoursToday.start_time, this.businessHoursToday.end_time);
+
+                        if (spansOvernight) {
+                            return currentMinutes >= startMinutes;
+                        } else {
+                            return currentMinutes >= startMinutes && currentMinutes <= endMinutes;
+                        }
+                    }
+
+                    return false;
+                },
+
                 init() {
-                    this.currentWeekDay = this.weekDays[new Date().getDay()]
-                    this.businessHoursToday = this.businessHours.find((day) => day.weekday['value'] === this.currentWeekDay)
-                    this.closed = !this.businessHoursToday['open']
-                    if (this.exceptions !== false && !this.closed ) {
-                        this.localDate = new Date(new Date().toLocaleString('en-US', {dateStyle: 'short', timeZone: 'Europe/Amsterdam' })).getTime() / 1000
-                        this.exceptions = this.exceptions.find((exception) => {
-                            return exception.active === true
-                                && (new Date(exception.start_date).getTime() / 1000 <= this.localDate)
-                                && (new Date(exception.end_date).getTime() / 1000 >= this.localDate)
-                        })
-                        this.closed = this.exceptions ? true : false
-                    }
-                    if (!this.closed) {
-                        this.startTime = this.businessHoursToday['start_time'].replace(':', '')
-                        this.endTime = this.businessHoursToday['end_time'].replace(':', '')
-                        this.localTime = new Date().toLocaleString('en-US', {timeStyle: 'short', hour12: false, timeZone: '{{ config:app:timezone }}' }).replace(':', '')
-                        this.localTime > this.startTime && this.localTime < this.endTime
-                            ? this.open = true
-                            : this.closed = true
-                    }
+                    this.currentWeekDay = this.weekDays[new Date().getDay()];
+                    this.businessHoursToday = this.getBusinessHours(this.currentWeekDay);
+                    
+                    this.open = this.checkIfOpen();
+                    this.closed = !this.open;
                 }
             }))
         })


### PR DESCRIPTION
Fixes #29.

Changes proposed in this pull request:
- Replace Date object comparisons with minutes-since-midnight for reliable time checks
- Fix edge case where early morning hours incorrectly showed as open
- Check previous day's hours before evaluating current day's schedule
- Properly handle business hours that span across midnight