### PR TITLE
FAQ sections to close smoothly 

### DIFF
--- a/resources/stubs/presets/faq/faq.antlers.html.stub
+++ b/resources/stubs/presets/faq/faq.antlers.html.stub
@@ -70,11 +70,12 @@
                     <div
                         x-show="expanded"
                         x-collapse
-                        class="p-2"
                     >
-                        {{ partial:typography/prose }}
-                            {{ text }}
-                        {{ /partial:typography/prose }}
+                        <div class="p-2">
+                            {{ partial:typography/prose }}
+                                {{ text }}
+                            {{ /partial:typography/prose }}
+                        </div>
                     </div>
                 </article>
 


### PR DESCRIPTION
Makes FAQ sections to close smoothly as Alpine's default height calculation is interrupted by a sudden change in padding

