### PR TITLE
Add location_country field to events.yaml and update addressCountry in show.antlers.html

### DIFF
--- a/resources/presets/events/resources/blueprints/collections/events/events.yaml
+++ b/resources/presets/events/resources/blueprints/collections/events/events.yaml
@@ -180,6 +180,28 @@ tabs:
               if:
                 {{ singular_handle }}_type: 'equals offline'
           -
+            handle: location_country
+            field:
+              input_type: text
+              antlers: false
+              display: Country
+              type: text
+              icon: text
+              listable: hidden
+              instructions_position: above
+              visibility: visible
+              always_save: false
+              width: 50
+              instructions: 'Enter the two-letter ISO country code (e.g., NL, US, GB). If left empty, the site locale will be used.'
+              placeholder: 'e.g., NL'
+              validate:
+                - sometimes
+                - max:2
+                - min:2
+                - alpha
+              if:
+                {{ singular_handle }}_type: 'equals offline'
+          -
             handle: {{ singular_handle }}_url
             field:
               input_type: url

--- a/resources/presets/events/resources/views/events/show.antlers.html
+++ b/resources/presets/events/resources/views/events/show.antlers.html
@@ -21,7 +21,7 @@
                     "@type": "PostalAddress",
                     "streetAddress": "{{ location_address }}",
                     "addressLocality": "{{ location_locality }}",
-                    "addressCountry": "NL"
+                    "addressCountry": "{{ location_country | upper ?? site:short_locale | upper }}"
                 }
             },
         {{ elseif {{ singular_handle }}_type.value == 'online' }}


### PR DESCRIPTION
- Introduced a new field `location_country` in events.yaml to capture the two-letter ISO country code.
- Updated the `addressCountry` in show.antlers.html to dynamically use the `location_country` value or fallback to the site's short locale.
