### PR TITLE
Enables live preview by default

### DIFF
--- a/resources/presets/events/content/collections/events.yaml
+++ b/resources/presets/events/content/collections/events.yaml
@@ -13,4 +13,3 @@ preview_targets:
   -
     label: Entry
     url: '{permalink}'
-    refresh: false


### PR DESCRIPTION
Removes the `refresh` property from the preview target configuration.

This ensures that the live preview functionality is enabled by default, providing a smoother user experience.