### PR TITLE
Add block groups preset

### DIFF
--- a/resources/presets/block_groups/app/FieldTypes/BlockGroupSelect.php
+++ b/resources/presets/block_groups/app/FieldTypes/BlockGroupSelect.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Fieldtypes;
+
+use Statamic\Fieldtypes\Select;
+use Statamic\Facades\GlobalSet;
+use Illuminate\Support\Str;
+
+class BlockGroupSelect extends Select
+{
+    protected $component = 'select';
+    protected $categories = ['special'];
+    
+    protected function configFieldItems(): array
+    {
+        return [
+            'placeholder' => [
+                'display' => 'Placeholder',
+                'instructions' => 'The placeholder text when nothing is selected.',
+                'type' => 'text',
+            ],
+        ];
+    }
+
+    public function preload(): array
+    {
+        $options = [];
+        
+        // Get the Block Groups global data
+        $globalSet = GlobalSet::findByHandle('block_groups');
+        
+        if ($globalSet && $globalSet->inCurrentSite()) {
+            $data = $globalSet->inCurrentSite()->data();
+            $blockGroups = $data->get('block_groups', []);
+            
+            foreach ($blockGroups as $group) {
+                // Only include groups that are available as blocks
+                if ($group['available_as_block'] ?? false) {
+                    $label = $group['label'] ?? 'Unnamed Block';
+                    $slug = Str::slug($label);
+                    $options[] = [
+                        'value' => $slug,
+                        'label' => $label
+                    ];
+                }
+            }
+        }
+        
+        return array_merge(parent::preload(), [
+            'options' => $options
+        ]);
+    }
+
+    public function preProcess($data)
+    {
+        return $data;
+    }
+
+    public function process($data)
+    {
+        return $data;
+    }
+}

--- a/resources/presets/block_groups/config.php
+++ b/resources/presets/block_groups/config.php
@@ -1,0 +1,57 @@
+<?php
+
+return [
+    'handle' => 'block_groups',
+    'name' => 'Block Groups',
+    'description' => 'Reusable page builder blocks that can be placed globally.',
+    'operations' => [
+        [
+            'type' => 'copy',
+            'input' => 'app/FieldTypes/BlockGroupSelect.php',
+            'output' => 'app/FieldTypes/BlockGroupSelect.php',
+        ],
+        [
+            'type' => 'copy',
+            'input' => 'content/globals/block_groups.yaml',
+            'output' => 'content/globals/block_groups.yaml',
+        ],
+        [
+            'type' => 'copy',
+            'input' => 'resources/blueprints/globals/block_groups.yaml',
+            'output' => 'resources/blueprints/globals/block_groups.yaml',
+        ],
+        [
+            'type' => 'copy',
+            'input' => 'resources/fieldsets/block_groups.yaml',
+            'output' => 'resources/fieldsets/block_groups.yaml',
+        ],
+        [
+            'type' => 'copy',
+            'input' => 'resources/views/snippets/_block_groups.antlers.html',
+            'output' => 'resources/views/snippets/_block_groups.antlers.html',
+        ],
+        [
+            'type' => 'copy',
+            'input' => 'resources/views/page_builder/_block_groups.antlers.html',
+            'output' => 'resources/views/page_builder/_block_groups.antlers.html',
+        ],
+        [
+            'type' => 'update_page_builder',
+            'block' => [
+                'name' => 'Block Groups',
+                'instructions' => 'Render a selected block group.',
+                'icon' => 'layers-filled',
+                'handle' => 'block_groups',
+            ],
+        ],
+        [
+            'type' => 'update_role',
+            'role' => 'editor',
+            'permissions' => ['view block_groups globals', 'edit block_groups globals'],
+        ],
+        [
+            'type' => 'notify',
+            'content' => "Add the following partials to your `resources/views/default.antlers.html` template:\n\n{{# Block Groups (before content, inside main) #}}\n{{ partial:snippets/block_groups position=\"before_content\" }}\n\n{{# Block Groups (after content, inside main) #}}\n{{ partial:snippets/block_groups position=\"after_content\" }}\n\n{{# Block Groups (before footer, outside main) #}}\n{{ partial:snippets/block_groups position=\"before_footer\" }}",
+        ],
+    ],
+];

--- a/resources/presets/block_groups/content/globals/block_groups.yaml
+++ b/resources/presets/block_groups/content/globals/block_groups.yaml
@@ -1,0 +1,1 @@
+title: Block Groups

--- a/resources/presets/block_groups/resources/blueprints/globals/block_groups.yaml
+++ b/resources/presets/block_groups/resources/blueprints/globals/block_groups.yaml
@@ -1,0 +1,94 @@
+tabs:
+  main:
+    display: 'Block Groups'
+    sections:
+      -
+        fields:
+          -
+            handle: block_groups
+            field:
+              type: replicator
+              display: 'Block Groups'
+              instructions: 'Each group can have different visibility settings and positions.'
+              button_label: 'Add Block Group'
+              collapse: accordion
+              sets:
+                main:
+                  display: Main
+                  sets:
+                    block_group:
+                      display: 'Block Group'
+                      instructions: 'A group of page builder blocks with visibility settings.'
+                      fields:
+                        -
+                          handle: label
+                          field:
+                            type: text
+                            display: 'Group Label'
+                            instructions: 'Internal label for this block group.'
+                            validate:
+                              - required
+                            width: 50
+                        -
+                          handle: available_as_block
+                          field:
+                            type: toggle
+                            display: 'Available as Block'
+                            instructions: 'Make this group available as a reusable page builder block.'
+                            default: false
+                            width: 50
+                        -
+                          handle: position
+                          field:
+                            type: select
+                            display: 'Auto Position'
+                            instructions: 'Where should these blocks automatically appear?'
+                            options:
+                              none: 'None (Manual only)'
+                              before_content: 'Before main content (inside main)'
+                              after_content: 'After main content (inside main)'
+                              before_footer: 'Before footer (outside main)'
+                            default: none
+                            width: 50
+                        -
+                          handle: visibility_mode
+                          field:
+                            type: button_group
+                            display: 'Visibility Mode'
+                            instructions: 'Control which pages show this block group.'
+                            options:
+                              all: 'All Pages'
+                              whitelist: 'Only Selected'
+                              blacklist: 'All Except Selected'
+                            default: all
+                            width: 50
+                            if:
+                              position: 'not none'
+                        -
+                          handle: whitelist_entries
+                          field:
+                            type: entries
+                            display: 'Show on These Pages'
+                            instructions: 'Select pages where this block group should appear.'
+                            collections:
+                              - pages
+                              - offerings
+                            create: false
+                            if:
+                              visibility_mode: 'equals whitelist'
+                              enabled: 'equals true'
+                        -
+                          handle: blacklist_entries
+                          field:
+                            type: entries
+                            display: 'Hide on These Pages'
+                            instructions: 'Select pages where this block group should NOT appear.'
+                            collections:
+                              - pages
+                              - offerings
+                            create: false
+                            if:
+                              visibility_mode: 'equals blacklist'
+                              enabled: 'equals true'
+                        -
+                          import: page_builder

--- a/resources/presets/block_groups/resources/fieldsets/block_groups.yaml
+++ b/resources/presets/block_groups/resources/fieldsets/block_groups.yaml
@@ -1,0 +1,13 @@
+title: 'Global Group Blocks'
+fields:
+  -
+    handle: block_group_info
+    field:
+      type: html
+      display: 'Available Block Groups'
+      html: '<div class="text-xs text-gray-700">To use a block group here, it must have "Available as Block" enabled in Block Groups Global. Select the block group below.</div>'
+  -
+    handle: block_group
+    field:
+      type: block_group_select
+      display: 'Block Group'

--- a/resources/presets/block_groups/resources/views/page_builder/_block_groups.antlers.html
+++ b/resources/presets/block_groups/resources/views/page_builder/_block_groups.antlers.html
@@ -1,0 +1,16 @@
+{{#
+    @name Group Blocks
+    @desc Renders a selected group block
+    @set page.page_builder.block_groups
+#}}
+
+<!-- /page_builder/_block_groups.antlers.html -->
+{{ block_groups:block_groups }}
+    {{ $slug = label | slugify }}
+    {{ if $slug == block:block_group && available_as_block }}
+        {{ page_builder scope="block" }}
+            {{ partial src="page_builder/{type}" }}
+        {{ /page_builder }}
+    {{ /if }}
+{{ /block_groups:block_groups }}
+<!-- End: /page_builder/_block_groups.antlers.html -->

--- a/resources/presets/block_groups/resources/views/snippets/_block_groups.antlers.html
+++ b/resources/presets/block_groups/resources/views/snippets/_block_groups.antlers.html
@@ -1,0 +1,65 @@
+{{#
+    @name Block Groups
+    @desc Renders Block Groups based on visibility settings
+    @param position The position to render blocks for (after_content, before_content or before_footer)
+#}}
+
+{{ $current_entry_id = id }}
+{{ $requested_position = position ?? 'after_content' }}
+{{ $slug = label | slugify}}
+
+{{# Loop through all block groups #}}
+{{ block_groups:block_groups }}
+    
+    {{# Only process groups with auto-positioning in the requested position #}}
+    {{ if position != 'none' && position == $requested_position }}
+        
+        {{ $should_show = false }}
+        
+        {{# Check visibility mode for this group #}}
+        {{ if visibility_mode == 'all' }}
+            {{ $should_show = true }}
+        {{ elseif visibility_mode == 'whitelist' }}
+            {{# Check if current page is in whitelist #}}
+            {{ whitelist_entries }}
+                {{ if id == $current_entry_id }}
+                    {{ $should_show = true }}
+                {{ /if }}
+            {{ /whitelist_entries }}
+        {{ elseif visibility_mode == 'blacklist' }}
+            {{ $should_show = true }}
+            {{# Check if current page is in blacklist #}}
+            {{ blacklist_entries }}
+                {{ if id == $current_entry_id }}
+                    {{ $should_show = false }}
+                {{ /if }}
+            {{ /blacklist_entries }}
+        {{ /if }}
+        
+        {{# Check for page-specific override if the fieldset is used #}}
+        {{ if visibility_override }}
+            {{ if visibility_override == 'show' }}
+                {{ $should_show = true }}
+            {{ elseif visibility_override == 'hide' }}
+                {{ $should_show = false }}
+            {{ /if }}
+        {{ /if }}
+        
+        {{# Render page builder blocks if conditions are met #}}
+        {{ if $should_show && page_builder }}
+            {{ if $requested_position == 'before_footer' }}
+                <div id="{{ $slug }}" class="py-12 md:py-16 lg:py-24 stack-12 md:stack-16 lg:stack-24" data-block-group="{{ $slug }}">
+                    {{ page_builder scope="block" }}
+                        {{ partial src="page_builder/{type}" }}
+                    {{ /page_builder }}
+                </div>
+            {{ else }}
+                {{ page_builder scope="block" }}
+                    {{ partial src="page_builder/{type}" }}
+                {{ /page_builder }}
+            {{ /if }}
+        {{ /if }}
+        
+    {{ /if }}
+    
+{{ /block_groups:block_groups }}


### PR DESCRIPTION
Changes proposed in this pull request:
- As discussed in https://github.com/studio1902/statamic-peak/discussions/442

**Open questions:**
1. **Naming**: Currently using "Global Block Groups" - open to suggestions for a clearer/better name
2. **Implementation approach**: Currently using snippets for rendering (called from both the default layout and the page builder block that allows selecting a block group) - should we consider a custom tag instead?
3. **Page Type enhancement**: Would it be valuable to extend this system to allow setting "Page Types" (e.g., "Product Pages", "Blog Posts") and select pages via those types in addition to individual page selection?

The current implementation provides both automatic placement with visibility controls and manual placement options. 

**Additional context:**
For some of our clients, we've created dedicated block groups for different collection types (e.g., product pages, blog posts) by hardcoding specific groups in the respective collection layout views. This allows clients to easily edit collection-specific content themselves without needing to understand complex visibility rules. This approach could be formalized through the Page Type enhancement mentioned above.

Looking forward to feedback on these design decisions!
